### PR TITLE
Reconstrói o projeto como biblioteca modular de automação BPMN (core, viewer, server, playground)

### DIFF
--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -23,6 +23,10 @@ node packages/server/dist/bin.js --static apps/playground/dist --samples bpmn-fi
 
 ## Como usar a interface
 
+Ha dois modos, alternados pelos botoes "Executar" e "Editar".
+
+### Executar
+
 - Selecione um exemplo ou use "Carregar arquivo" para abrir um `.bpmn` proprio.
 - "Iniciar" executa em modo automation: a execucao pausa em tarefas de usuario e
   eventos de captura, exibindo botoes para concluir ou sinalizar.
@@ -31,3 +35,15 @@ node packages/server/dist/bin.js --static apps/playground/dist --samples bpmn-fi
 - O painel mostra status, variaveis e o historico da execucao; o diagrama
   destaca nos concluidos, tokens ativos, atividades em espera e fluxos
   percorridos.
+- Diagramas sem layout sao posicionados automaticamente; use "Ajustar" para
+  enquadrar e o mouse para navegar (arrastar) e dar zoom (roda).
+
+### Editar
+
+- Cria e edita diagramas com o editor `bpmn-js` (paleta a esquerda).
+- "Novo" comeca um diagrama em branco; "Abrir arquivo" carrega um `.bpmn`.
+- "Validar" verifica a estrutura BPMN com o `@bpmn-flow/core` e lista erros e
+  avisos.
+- "Salvar no repositorio" valida e grava o `.bpmn` no diretorio de exemplos do
+  servidor (`--samples`). A gravacao exige o `@bpmn-flow/server` em execucao.
+  Nomes aceitam apenas letras, numeros, hifen e sublinhado.

--- a/apps/playground/index.html
+++ b/apps/playground/index.html
@@ -8,7 +8,13 @@
   <body>
     <header class="app-header">
       <h1>BPMN Flow</h1>
-      <div class="toolbar">
+
+      <div class="modes" role="tablist">
+        <button id="mode-run" type="button" class="mode active">Executar</button>
+        <button id="mode-edit" type="button" class="mode">Editar</button>
+      </div>
+
+      <div class="toolbar" id="run-toolbar">
         <select id="sample" aria-label="Exemplo BPMN"></select>
         <label class="file-button">
           Carregar arquivo
@@ -19,23 +25,41 @@
         <button id="reset" type="button" class="secondary">Reiniciar</button>
         <button id="fit" type="button" class="secondary">Ajustar</button>
       </div>
+
+      <div class="toolbar hidden" id="edit-toolbar">
+        <button id="new-diagram" type="button">Novo</button>
+        <label class="file-button">
+          Abrir arquivo
+          <input id="edit-file" type="file" accept=".bpmn,.xml" hidden />
+        </label>
+        <input id="save-name" class="name-input" placeholder="nome-do-arquivo" />
+        <button id="validate" type="button" class="secondary">Validar</button>
+        <button id="save" type="button">Salvar no repositorio</button>
+        <button id="edit-fit" type="button" class="secondary">Ajustar</button>
+      </div>
     </header>
 
     <main class="app-main">
       <section id="diagram" class="diagram" aria-label="Diagrama BPMN"></section>
+      <section id="editor" class="diagram hidden" aria-label="Editor BPMN"></section>
 
       <aside class="panel">
-        <div class="panel-block">
+        <div class="panel-block" data-mode="edit" hidden>
+          <h2>Validacao</h2>
+          <div id="validation" class="validation"></div>
+        </div>
+
+        <div class="panel-block" data-mode="run">
           <h2>Estado</h2>
           <p id="status" class="status">Carregue um diagrama para comecar.</p>
         </div>
 
-        <div class="panel-block">
+        <div class="panel-block" data-mode="run">
           <h2>Acoes pendentes</h2>
           <div id="actions" class="actions"></div>
         </div>
 
-        <div class="panel-block">
+        <div class="panel-block" data-mode="run">
           <h2>Variaveis</h2>
           <textarea
             id="variables"
@@ -46,7 +70,7 @@
           <pre id="variables-view" class="variables-view"></pre>
         </div>
 
-        <div class="panel-block">
+        <div class="panel-block" data-mode="run">
           <h2>Historico</h2>
           <ol id="log" class="log"></ol>
         </div>

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "@bpmn-flow/core": "^0.1.0",
-    "@bpmn-flow/viewer": "^0.1.0"
+    "@bpmn-flow/viewer": "^0.1.0",
+    "bpmn-js": "^18.21.0"
   },
   "devDependencies": {
     "vite": "^8.1.4"

--- a/apps/playground/src/api.ts
+++ b/apps/playground/src/api.ts
@@ -1,0 +1,36 @@
+import type { ValidationIssue } from '@bpmn-flow/core';
+
+export interface SaveResult {
+  name: string;
+  issues: ValidationIssue[];
+}
+
+/** Sample list from the server, or null when no API is available (dev). */
+export async function fetchSampleNames(): Promise<string[] | null> {
+  try {
+    const res = await fetch('/api/samples');
+    if (!res.ok) return null;
+    const list = (await res.json()) as { name: string }[];
+    return list.map((s) => s.name);
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchSampleXml(name: string): Promise<string> {
+  const res = await fetch(`/api/samples/${encodeURIComponent(name)}`);
+  if (!res.ok) throw new Error(`Falha ao carregar "${name}".`);
+  return res.text();
+}
+
+/** Validates and saves a diagram into the server's samples directory. */
+export async function saveSample(name: string, xml: string): Promise<SaveResult> {
+  const res = await fetch('/api/samples', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name, xml }),
+  });
+  const data = (await res.json()) as SaveResult & { error?: string };
+  if (!res.ok) throw new Error(data.error ?? 'Falha ao salvar.');
+  return data;
+}

--- a/apps/playground/src/editor.ts
+++ b/apps/playground/src/editor.ts
@@ -1,0 +1,63 @@
+import { validateBpmn, type ValidationResult } from '@bpmn-flow/core';
+import BpmnModeler from 'bpmn-js/lib/Modeler';
+
+/** Blank diagram with a single start event, ready to be extended. */
+const BLANK = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  id="Definitions_new" targetNamespace="http://bpmn-flow">
+  <bpmn:process id="Process_new" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Inicio" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_new">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`;
+
+interface Canvas {
+  zoom(mode: string): void;
+}
+
+/**
+ * Wraps a bpmn-js modeler to create and edit BPMN diagrams, exporting valid
+ * BPMN 2.0 XML (with diagram interchange) and validating it with the core.
+ */
+export class BpmnEditor {
+  private readonly modeler: BpmnModeler;
+
+  constructor(container: HTMLElement) {
+    this.modeler = new BpmnModeler({ container });
+  }
+
+  async newDiagram(): Promise<void> {
+    await this.modeler.importXML(BLANK);
+    this.fit();
+  }
+
+  async open(xml: string): Promise<void> {
+    await this.modeler.importXML(xml);
+    this.fit();
+  }
+
+  async getXml(): Promise<string> {
+    const { xml } = await this.modeler.saveXML({ format: true });
+    return xml ?? '';
+  }
+
+  async validate(): Promise<ValidationResult> {
+    return validateBpmn(await this.getXml());
+  }
+
+  fit(): void {
+    (this.modeler.get('canvas') as Canvas).zoom('fit-viewport');
+  }
+
+  destroy(): void {
+    this.modeler.destroy();
+  }
+}

--- a/apps/playground/src/main.ts
+++ b/apps/playground/src/main.ts
@@ -76,7 +76,7 @@ async function loadDiagram(xml: string): Promise<void> {
   currentXml = xml;
   currentModel = await parseBpmn(xml);
   nodesById = flattenNodes(currentModel);
-  viewer.load(xml);
+  await viewer.load(xml);
   teardownEngine();
   clearLog();
   els.actions.replaceChildren();

--- a/apps/playground/src/main.ts
+++ b/apps/playground/src/main.ts
@@ -6,12 +6,18 @@ import {
   type ExecutionSnapshot,
   type FlowNode,
   type TokenSnapshot,
+  type ValidationResult,
 } from '@bpmn-flow/core';
 import { BpmnFlowViewer } from '@bpmn-flow/viewer';
 import '@bpmn-flow/viewer/styles.css';
+import 'bpmn-js/dist/assets/diagram-js.css';
+import 'bpmn-js/dist/assets/bpmn-js.css';
+import 'bpmn-js/dist/assets/bpmn-font/css/bpmn.css';
 import './style.css';
+import { fetchSampleNames, fetchSampleXml, saveSample } from './api.js';
+import { BpmnEditor } from './editor.js';
 
-const SAMPLES = import.meta.glob('../../../bpmn-files/*.bpmn', {
+const BUNDLED = import.meta.glob('../../../bpmn-files/*.bpmn', {
   query: '?raw',
   import: 'default',
   eager: true,
@@ -24,12 +30,25 @@ const $ = <T extends HTMLElement>(id: string): T => {
 };
 
 const els = {
+  modeRun: $<HTMLButtonElement>('mode-run'),
+  modeEdit: $<HTMLButtonElement>('mode-edit'),
+  runToolbar: $<HTMLDivElement>('run-toolbar'),
+  editToolbar: $<HTMLDivElement>('edit-toolbar'),
+  diagram: $<HTMLElement>('diagram'),
+  editorEl: $<HTMLElement>('editor'),
   sample: $<HTMLSelectElement>('sample'),
   file: $<HTMLInputElement>('file'),
   start: $<HTMLButtonElement>('start'),
   autorun: $<HTMLButtonElement>('autorun'),
   reset: $<HTMLButtonElement>('reset'),
   fit: $<HTMLButtonElement>('fit'),
+  newDiagram: $<HTMLButtonElement>('new-diagram'),
+  editFile: $<HTMLInputElement>('edit-file'),
+  saveName: $<HTMLInputElement>('save-name'),
+  validate: $<HTMLButtonElement>('validate'),
+  save: $<HTMLButtonElement>('save'),
+  editFit: $<HTMLButtonElement>('edit-fit'),
+  validation: $<HTMLDivElement>('validation'),
   status: $<HTMLParagraphElement>('status'),
   actions: $<HTMLDivElement>('actions'),
   variables: $<HTMLTextAreaElement>('variables'),
@@ -37,13 +56,47 @@ const els = {
   log: $<HTMLOListElement>('log'),
 };
 
-const viewer = new BpmnFlowViewer({ container: 'diagram' });
+const viewer = new BpmnFlowViewer({ container: els.diagram });
 
 let currentXml = '';
 let currentModel: BpmnModel | undefined;
 let nodesById = new Map<string, FlowNode>();
 let engine: WorkflowEngine | undefined;
 let unbindViewer: (() => void) | undefined;
+let editor: BpmnEditor | undefined;
+let remoteSamples = false;
+
+// --- Sample loading ----------------------------------------------------
+
+async function populateSamples(): Promise<void> {
+  els.sample.replaceChildren();
+  const names = await fetchSampleNames();
+  if (names) {
+    remoteSamples = true;
+    for (const name of names.sort((a, b) => a.localeCompare(b))) {
+      els.sample.append(new Option(name, name));
+    }
+    return;
+  }
+  remoteSamples = false;
+  for (const [path, xml] of Object.entries(BUNDLED).sort(([a], [b]) => a.localeCompare(b))) {
+    const name = path.split('/').pop()?.replace('.bpmn', '') ?? path;
+    const option = new Option(name, name);
+    option.dataset.xml = xml;
+    els.sample.append(option);
+  }
+}
+
+async function loadSelectedSample(): Promise<void> {
+  const name = els.sample.value;
+  if (!name) return;
+  const xml = remoteSamples
+    ? await fetchSampleXml(name)
+    : els.sample.selectedOptions[0]?.dataset.xml;
+  if (xml) await loadDiagram(xml);
+}
+
+// --- Execution (run mode) ---------------------------------------------
 
 function flattenNodes(model: BpmnModel): Map<string, FlowNode> {
   const map = new Map<string, FlowNode>();
@@ -57,19 +110,12 @@ function flattenNodes(model: BpmnModel): Map<string, FlowNode> {
   return map;
 }
 
-function label(nodeId: string): string {
-  const node = nodesById.get(nodeId);
-  return node?.name ?? nodeId;
-}
+const label = (nodeId: string): string => nodesById.get(nodeId)?.name ?? nodeId;
 
 function log(message: string): void {
   const item = document.createElement('li');
   item.textContent = message;
   els.log.prepend(item);
-}
-
-function clearLog(): void {
-  els.log.replaceChildren();
 }
 
 async function loadDiagram(xml: string): Promise<void> {
@@ -78,7 +124,7 @@ async function loadDiagram(xml: string): Promise<void> {
   nodesById = flattenNodes(currentModel);
   await viewer.load(xml);
   teardownEngine();
-  clearLog();
+  els.log.replaceChildren();
   els.actions.replaceChildren();
   els.variablesView.textContent = '';
   els.status.textContent = `Diagrama carregado: ${currentModel.processes[0]?.name ?? currentModel.processes[0]?.id ?? 'processo'}.`;
@@ -92,8 +138,7 @@ function teardownEngine(): void {
 
 function readVariables(): Record<string, unknown> {
   const raw = els.variables.value.trim();
-  if (!raw) return {};
-  return JSON.parse(raw) as Record<string, unknown>;
+  return raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
 }
 
 function newEngine(mode: EngineMode, variables: Record<string, unknown>): WorkflowEngine {
@@ -131,8 +176,8 @@ function addActionButtons(token: TokenSnapshot): void {
   if (token.waitReason === 'eventBasedGateway') {
     const node = nodesById.get(token.nodeId);
     for (const flowId of node?.outgoing ?? []) {
-      const target = currentModel?.processes[0]?.sequenceFlows.find((f) => f.id === flowId);
-      if (target) actionButton(`Sinalizar ${label(target.targetRef)}`, () => signal(target.targetRef));
+      const flow = currentModel?.processes[0]?.sequenceFlows.find((f) => f.id === flowId);
+      if (flow) actionButton(`Sinalizar ${label(flow.targetRef)}`, () => signal(flow.targetRef));
     }
     return;
   }
@@ -191,27 +236,92 @@ function fail(error: unknown): void {
   els.status.textContent = `Erro: ${error instanceof Error ? error.message : String(error)}`;
 }
 
-function populateSamples(): void {
-  const entries = Object.entries(SAMPLES).sort(([a], [b]) => a.localeCompare(b));
-  for (const [path, xml] of entries) {
-    const name = path.split('/').pop()?.replace('.bpmn', '') ?? path;
-    const option = document.createElement('option');
-    option.value = name;
-    option.textContent = name;
-    option.dataset.xml = xml;
-    els.sample.append(option);
+// --- Editor (edit mode) ------------------------------------------------
+
+async function ensureEditor(): Promise<BpmnEditor> {
+  if (!editor) {
+    editor = new BpmnEditor(els.editorEl);
+    if (currentXml) await editor.open(currentXml).catch(() => editor?.newDiagram());
+    else await editor.newDiagram();
+  }
+  return editor;
+}
+
+function renderValidation(result: ValidationResult, extra?: string): void {
+  els.validation.replaceChildren();
+  const header = document.createElement('p');
+  header.className = result.valid ? 'valid-ok' : 'valid-err';
+  header.textContent = result.valid ? 'Diagrama valido.' : 'Diagrama invalido.';
+  els.validation.append(header);
+  for (const issue of result.issues) {
+    const item = document.createElement('p');
+    item.className = `issue issue-${issue.severity}`;
+    item.textContent = `${issue.severity === 'error' ? 'Erro' : 'Aviso'}: ${issue.message}`;
+    els.validation.append(item);
+  }
+  if (extra) {
+    const note = document.createElement('p');
+    note.className = 'valid-ok';
+    note.textContent = extra;
+    els.validation.append(note);
   }
 }
 
-function selectedSampleXml(): string | undefined {
-  const option = els.sample.selectedOptions[0];
-  return option?.dataset.xml;
+function validationMessage(message: string, ok = false): void {
+  els.validation.replaceChildren();
+  const p = document.createElement('p');
+  p.className = ok ? 'valid-ok' : 'valid-err';
+  p.textContent = message;
+  els.validation.append(p);
 }
 
-els.sample.addEventListener('change', () => {
-  const xml = selectedSampleXml();
-  if (xml) void loadDiagram(xml);
-});
+async function validate(): Promise<void> {
+  const result = await (await ensureEditor()).validate();
+  renderValidation(result);
+}
+
+async function save(): Promise<void> {
+  const name = els.saveName.value.trim();
+  if (!name) {
+    validationMessage('Informe um nome para o arquivo.');
+    return;
+  }
+  const active = await ensureEditor();
+  const result = await active.validate();
+  renderValidation(result);
+  if (!result.valid) return;
+  try {
+    const saved = await saveSample(name, await active.getXml());
+    await populateSamples();
+    els.sample.value = saved.name;
+    renderValidation(result, `Salvo como ${saved.name}.bpmn no repositorio.`);
+  } catch (error) {
+    validationMessage(error instanceof Error ? error.message : String(error));
+  }
+}
+
+// --- Mode switching ----------------------------------------------------
+
+async function setMode(mode: 'run' | 'edit'): Promise<void> {
+  const editing = mode === 'edit';
+  els.modeEdit.classList.toggle('active', editing);
+  els.modeRun.classList.toggle('active', !editing);
+  els.runToolbar.classList.toggle('hidden', editing);
+  els.editToolbar.classList.toggle('hidden', !editing);
+  els.diagram.classList.toggle('hidden', editing);
+  els.editorEl.classList.toggle('hidden', !editing);
+  for (const block of document.querySelectorAll<HTMLElement>('[data-mode]')) {
+    block.hidden = block.dataset.mode !== mode;
+  }
+  if (editing) {
+    const active = await ensureEditor();
+    active.fit();
+  }
+}
+
+// --- Wiring ------------------------------------------------------------
+
+els.sample.addEventListener('change', () => void loadSelectedSample());
 els.file.addEventListener('change', async () => {
   const file = els.file.files?.[0];
   if (file) await loadDiagram(await file.text());
@@ -223,6 +333,23 @@ els.reset.addEventListener('click', () => {
 });
 els.fit.addEventListener('click', () => viewer.fit());
 
-populateSamples();
-const first = selectedSampleXml();
-if (first) void loadDiagram(first);
+els.modeRun.addEventListener('click', () => void setMode('run'));
+els.modeEdit.addEventListener('click', () => void setMode('edit'));
+els.newDiagram.addEventListener('click', async () => {
+  await (await ensureEditor()).newDiagram();
+  validationMessage('Novo diagrama criado.', true);
+});
+els.editFile.addEventListener('change', async () => {
+  const file = els.editFile.files?.[0];
+  if (file) await (await ensureEditor()).open(await file.text());
+});
+els.validate.addEventListener('click', () => void validate());
+els.save.addEventListener('click', () => void save());
+els.editFit.addEventListener('click', () => void ensureEditor().then((e) => e.fit()));
+
+async function init(): Promise<void> {
+  await populateSamples();
+  await loadSelectedSample();
+}
+
+void init();

--- a/apps/playground/src/style.css
+++ b/apps/playground/src/style.css
@@ -50,6 +50,57 @@ body {
   align-items: center;
 }
 
+.hidden {
+  display: none !important;
+}
+
+.modes {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.mode {
+  background: var(--surface);
+  color: var(--text);
+}
+
+.mode.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.name-input {
+  font: inherit;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  min-width: 12rem;
+}
+
+.validation p {
+  margin: 0 0 0.35rem;
+  font-size: 0.85rem;
+}
+
+.valid-ok {
+  color: #2f9e44;
+  font-weight: 600;
+}
+
+.valid-err {
+  color: #e03131;
+  font-weight: 600;
+}
+
+.issue-error {
+  color: #e03131;
+}
+
+.issue-warning {
+  color: #e8590c;
+}
+
 select,
 button,
 .file-button {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1924,6 +1924,22 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/bpmn-auto-layout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bpmn-auto-layout/-/bpmn-auto-layout-1.3.0.tgz",
+      "integrity": "sha512-ufjMy1MaaZxkQF7f2wY6EL6TnRMSFr/r9eBhp0QvS41UHXW77aQVt65+dn2MmVMlHdyvZyOMNYXO2qYpgX6bQA==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "dependencies": {
+        "bpmn-moddle": "^10.0.0",
+        "min-dash": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/bpmn-moddle": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-10.0.0.tgz",
@@ -4071,6 +4087,7 @@
       "license": "MIT",
       "dependencies": {
         "@bpmn-flow/core": "^0.1.0",
+        "bpmn-auto-layout": "^1.3.0",
         "bpmn-visualization": "^0.48.0"
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@bpmn-flow/core": "^0.1.0",
-        "@bpmn-flow/viewer": "^0.1.0"
+        "@bpmn-flow/viewer": "^0.1.0",
+        "bpmn-js": "^18.21.0"
       },
       "devDependencies": {
         "vite": "^8.1.4"
@@ -52,6 +53,16 @@
     "node_modules/@bpmn-flow/viewer": {
       "resolved": "packages/viewer",
       "link": true
+    },
+    "node_modules/@bpmn-io/diagram-js-ui": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.4.tgz",
+      "integrity": "sha512-I678ZGtoH7z7FgzFhzzppM9ThsJ3Lh83kW3GjhjG3xyYciIPYHMaHK1MABP8F69H9pFZpViM6t4qUo8dwrVz0w==",
+      "license": "MIT",
+      "dependencies": {
+        "htm": "^3.1.1",
+        "preact": "^10.29.2"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
@@ -1940,6 +1951,25 @@
         "node": ">= 18"
       }
     },
+    "node_modules/bpmn-js": {
+      "version": "18.21.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.21.0.tgz",
+      "integrity": "sha512-TVPsgsTnD24jrcZ5bjU3LAfhEp4UtfnRIQ53Spf7Cs2nMofFU27uZ/Z5MTxNzfB5PVczjZbx7UTRmq+RcCZ7HA==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "bpmn-moddle": "^10.0.0",
+        "diagram-js": "^15.20.0",
+        "diagram-js-direct-editing": "^3.4.0",
+        "ids": "^3.0.2",
+        "inherits-browser": "^0.1.0",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.3.0",
+        "tiny-svg": "^4.1.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bpmn-moddle": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-10.0.0.tgz",
@@ -2031,6 +2061,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2113,6 +2152,63 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diagram-js": {
+      "version": "15.22.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.22.0.tgz",
+      "integrity": "sha512-xcX1e4lmRCrpwlnNqNHVqY8Xp4i70tXUZwO39IzRJsXWq6F+/osNs4biehnb5ZlHIzjZcEHWzOx/vlIui4qS8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/diagram-js-ui": "^0.2.4",
+        "clsx": "^2.1.1",
+        "didi": "^11.0.0",
+        "inherits-browser": "^0.1.0",
+        "min-dash": "^5.1.0",
+        "min-dom": "^5.3.0",
+        "object-refs": "^0.4.0",
+        "path-intersection": "^4.1.0",
+        "tiny-svg": "^4.1.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/diagram-js-direct-editing": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.5.0.tgz",
+      "integrity": "sha512-oB0bhyEDvGZ/f/XdznLBPPq4K20I945ZUThI6CuE7JmpZPrK10olx0AVvBpaW4+R7LlvEUXqGpILrmENZp5ewg==",
+      "license": "MIT",
+      "dependencies": {
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.3.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "peerDependencies": {
+        "diagram-js": "*"
+      }
+    },
+    "node_modules/didi": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/didi/-/didi-11.0.0.tgz",
+      "integrity": "sha512-PzCfRzQttvFpVcYMbSF7h8EsWjeJpVjWH4qDhB5LkMi1ILvHq4Ob0vhM2wLFziPkbUBi+PAo7ODbe2sacR7nJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.12"
+      }
+    },
+    "node_modules/domify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domify/-/domify-3.0.0.tgz",
+      "integrity": "sha512-bs2yO68JDFOm6rKv8f0EnrM2cENduhRkpqOtt/s5l5JBA/eqGBZCzLPmdYoHtJ6utgLGgcBajFsEQbl12pT0lQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-module-lexer": {
@@ -2554,6 +2650,21 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ids": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ids/-/ids-3.0.2.tgz",
+      "integrity": "sha512-t6YJP4mdC+GHF96Nbis/4FEANhP/8VWmYMvUuYpXvSdrhg5hpIVbq2XZlOA3UWTbtdwPCi0q7jEXOdHkAnqOnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.12"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2573,6 +2684,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits-browser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.1.0.tgz",
+      "integrity": "sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw==",
+      "license": "ISC"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -2982,6 +3099,16 @@
       "integrity": "sha512-HAvN6XzmCQj+js43G9sJRRw8kj/7DvoxN7qhoIN9Xo5ZN1NMljtpyKs/NunXmw0QSWwlgZzNv6tLeEa4xaZ0tg==",
       "license": "MIT"
     },
+    "node_modules/min-dom": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-5.3.0.tgz",
+      "integrity": "sha512-0w5FEBgPAyHhmFojW3zxd7we3D+m5XYS3E/06OyvxmbHJoiQVa4Nagj6RWvoAKYRw5xth6cP5TMePc5cR1M9hA==",
+      "license": "MIT",
+      "dependencies": {
+        "domify": "^3.0.0",
+        "min-dash": "^5.0.0"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -3098,6 +3225,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-refs": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-refs/-/object-refs-0.4.0.tgz",
+      "integrity": "sha512-6kJqKWryKZmtte6QYvouas0/EIJKPI1/MMIuRsiBlNuhIMfqYTggzX2F1AJ2+cDs288xyi9GL7FyasHINR98BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
@@ -3185,6 +3321,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-intersection": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-4.1.0.tgz",
+      "integrity": "sha512-urUP6WvhnxbHPdHYl6L7Yrc6+1ny6uOFKPCzPxTSUSYGHG0o94RmI7SvMMaScNAM5RtTf08bg4skc6/kjfne3A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.20"
       }
     },
     "node_modules/path-key": {
@@ -3314,6 +3459,24 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
           "optional": true
         }
       }
@@ -3602,6 +3765,15 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/tiny-svg": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-4.1.4.tgz",
+      "integrity": "sha512-cBaEACCbouYrQc9RG+eTXnPYosX1Ijqty/I6DdXovwDd89Pwu4jcmpOR7BuFEF9YCcd7/AWwasE0207WMK7hdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/tinybench": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,8 @@ export * from './model/kinds.js';
 export * from './model/types.js';
 export { ProcessGraph } from './model/graph.js';
 export { parseBpmn } from './parser/parse.js';
+export { validateBpmn, validateModel } from './validate.js';
+export type { ValidationIssue, ValidationResult } from './validate.js';
 export { WorkflowEngine } from './engine/engine.js';
 export { BpmnError, HandlerRegistry } from './engine/handlers.js';
 export type { HandlerContext, TaskHandler, HandlerSelector } from './engine/handlers.js';

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -1,0 +1,82 @@
+import { BpmnParseError } from './errors.js';
+import { parseBpmn } from './parser/parse.js';
+import type { BpmnModel, FlowNode, ProcessModel } from './model/types.js';
+
+export interface ValidationIssue {
+  severity: 'error' | 'warning';
+  message: string;
+  nodeId?: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  issues: ValidationIssue[];
+  model?: BpmnModel;
+}
+
+function validateProcess(process: ProcessModel, issues: ValidationIssue[]): void {
+  const starts = process.flowNodes.filter((n) => n.kind === 'startEvent');
+  const ends = process.flowNodes.filter((n) => n.kind === 'endEvent');
+
+  if (starts.length === 0) {
+    issues.push({ severity: 'error', message: `Process "${process.id}" has no start event.` });
+  }
+  if (ends.length === 0) {
+    issues.push({
+      severity: 'warning',
+      message: `Process "${process.id}" has no end event.`,
+    });
+  }
+
+  for (const node of process.flowNodes) {
+    checkNode(node, issues);
+    if (node.process) validateProcess(node.process, issues);
+  }
+}
+
+function checkNode(node: FlowNode, issues: ValidationIssue[]): void {
+  const isStart = node.kind === 'startEvent';
+  const isEnd = node.kind === 'endEvent';
+  const isBoundary = node.kind === 'boundaryEvent';
+
+  if (!isStart && !isBoundary && node.incoming.length === 0) {
+    issues.push({
+      severity: 'warning',
+      message: `"${node.name ?? node.id}" is unreachable (no incoming flow).`,
+      nodeId: node.id,
+    });
+  }
+  if (!isEnd && node.outgoing.length === 0) {
+    issues.push({
+      severity: 'warning',
+      message: `"${node.name ?? node.id}" is a dead end (no outgoing flow).`,
+      nodeId: node.id,
+    });
+  }
+}
+
+/** Validates an already-parsed model without re-parsing. */
+export function validateModel(model: BpmnModel): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  if (model.processes.length === 0) {
+    issues.push({ severity: 'error', message: 'No process found in the model.' });
+  }
+  for (const process of model.processes) validateProcess(process, issues);
+  return issues;
+}
+
+/**
+ * Parses and validates BPMN XML, reporting structural problems. The result is
+ * `valid` when there are no error-severity issues (warnings are advisory).
+ */
+export async function validateBpmn(xml: string): Promise<ValidationResult> {
+  let model: BpmnModel;
+  try {
+    model = await parseBpmn(xml);
+  } catch (error) {
+    const message = error instanceof BpmnParseError ? error.message : String(error);
+    return { valid: false, issues: [{ severity: 'error', message }] };
+  }
+  const issues = validateModel(model);
+  return { valid: !issues.some((i) => i.severity === 'error'), issues, model };
+}

--- a/packages/core/test/validate.test.ts
+++ b/packages/core/test/validate.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { validateBpmn } from '../src/index.js';
+import { LINEAR } from './fixtures.js';
+
+const NO_START = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="d" targetNamespace="t">
+  <bpmn:process id="P" isExecutable="true">
+    <bpmn:task id="A" />
+  </bpmn:process>
+</bpmn:definitions>`;
+
+describe('validateBpmn', () => {
+  it('accepts a well-formed process', async () => {
+    const result = await validateBpmn(LINEAR);
+    expect(result.valid).toBe(true);
+    expect(result.issues.filter((i) => i.severity === 'error')).toHaveLength(0);
+  });
+
+  it('reports a missing start event as an error', async () => {
+    const result = await validateBpmn(NO_START);
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.message.includes('no start event'))).toBe(true);
+  });
+
+  it('warns about unreachable and dead-end nodes', async () => {
+    const result = await validateBpmn(NO_START);
+    expect(result.issues.some((i) => i.severity === 'warning' && i.nodeId === 'A')).toBe(true);
+  });
+
+  it('flags invalid XML as invalid', async () => {
+    const result = await validateBpmn('<nope>');
+    expect(result.valid).toBe(false);
+  });
+});

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -39,6 +39,7 @@ Variaveis de ambiente equivalentes: `PORT`, `STATIC_DIR`, `SAMPLES_DIR`.
 | --------------------------------- | ------------------------------ | ---------------------------------- |
 | `GET /api/health`                 | -                              | Verificacao de disponibilidade.    |
 | `POST /api/parse`                 | `{ xml }`                      | Modelo normalizado do diagrama.    |
+| `POST /api/validate`              | `{ xml }`                      | Valida a estrutura BPMN.           |
 | `POST /api/sessions`              | `{ xml, mode?, variables? }`   | Cria e inicia uma execucao.        |
 | `GET /api/sessions`               | -                              | Lista as sessoes ativas.           |
 | `GET /api/sessions/:id`           | -                              | Snapshot atual da sessao.          |
@@ -47,6 +48,7 @@ Variaveis de ambiente equivalentes: `PORT`, `STATIC_DIR`, `SAMPLES_DIR`.
 | `DELETE /api/sessions/:id`        | -                              | Remove a sessao.                   |
 | `GET /api/samples`                | -                              | Lista os `.bpmn` do diretorio.     |
 | `GET /api/samples/:name`          | -                              | Retorna o XML de um exemplo.       |
+| `POST /api/samples`               | `{ name, xml }`                | Valida e salva um `.bpmn` no dir.  |
 
 As sessoes mantem instancias do motor em memoria, permitindo executar um
 processo passo a passo por HTTP.

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { extname, join, normalize } from 'node:path';
-import { parseBpmn } from '@bpmn-flow/core';
+import { parseBpmn, validateBpmn } from '@bpmn-flow/core';
 import { Hono } from 'hono';
 import { SampleProvider } from './samples.js';
 import { SessionStore, type CreateSessionInput } from './sessions.js';
@@ -38,6 +38,12 @@ export function createApp(options: AppOptions = {}): Hono {
   app.post('/api/parse', async (c) => {
     const { xml } = await c.req.json<{ xml: string }>();
     return c.json(await parseBpmn(xml));
+  });
+
+  app.post('/api/validate', async (c) => {
+    const { xml } = await c.req.json<{ xml: string }>();
+    const { valid, issues } = await validateBpmn(xml);
+    return c.json({ valid, issues });
   });
 
   app.post('/api/sessions', async (c) => {
@@ -78,11 +84,24 @@ export function createApp(options: AppOptions = {}): Hono {
         ? c.body(xml, 200, { 'content-type': MIME['.bpmn']! })
         : c.json({ error: 'Sample not found' }, 404);
     });
+    app.post('/api/samples', async (c) => {
+      const { name, xml } = await c.req.json<{ name: string; xml: string }>();
+      const validation = await validateBpmn(xml);
+      if (!validation.valid) {
+        return c.json({ error: 'Invalid BPMN', issues: validation.issues }, 400);
+      }
+      const stored = await samples.write(name, xml);
+      return c.json({ name: stored, issues: validation.issues }, 201);
+    });
   }
 
   app.onError((err, c) => {
     if (err.name === 'SessionNotFoundError') return c.json({ error: err.message }, 404);
-    if (err.name === 'BpmnParseError' || err.name === 'BpmnValidationError') {
+    if (
+      err.name === 'BpmnParseError' ||
+      err.name === 'BpmnValidationError' ||
+      err.name === 'InvalidSampleNameError'
+    ) {
       return c.json({ error: err.message }, 400);
     }
     return c.json({ error: err.message }, 500);

--- a/packages/server/src/samples.ts
+++ b/packages/server/src/samples.ts
@@ -1,9 +1,16 @@
-import { readdir, readFile } from 'node:fs/promises';
+import { readdir, readFile, writeFile } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 
 export interface SampleInfo {
   name: string;
   file: string;
+}
+
+export class InvalidSampleNameError extends Error {
+  constructor() {
+    super('Invalid sample name: use only letters, numbers, dashes and underscores.');
+    this.name = 'InvalidSampleNameError';
+  }
 }
 
 /**
@@ -32,5 +39,21 @@ export class SampleProvider {
     } catch {
       return undefined;
     }
+  }
+
+  /** Writes a `.bpmn` file, returning the stored name. */
+  async write(name: string, xml: string): Promise<string> {
+    const safe = SampleProvider.safeName(name);
+    await writeFile(join(this.directory, `${safe}.bpmn`), xml, 'utf8');
+    return safe;
+  }
+
+  /** Rejects names that could escape the directory or use unsafe characters. */
+  static safeName(name: string): string {
+    const stripped = name.trim().replace(/\.bpmn$/i, '');
+    if (!/^[A-Za-z0-9_-]+$/.test(stripped)) {
+      throw new InvalidSampleNameError();
+    }
+    return stripped;
   }
 }

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@bpmn-flow/core": "^0.1.0",
+    "bpmn-auto-layout": "^1.3.0",
     "bpmn-visualization": "^0.48.0"
   }
 }

--- a/packages/viewer/src/index.ts
+++ b/packages/viewer/src/index.ts
@@ -1,4 +1,5 @@
 import type { ExecutionSnapshot, WorkflowEngine } from '@bpmn-flow/core';
+import { layoutProcess } from 'bpmn-auto-layout';
 import { BpmnVisualization, FitType } from 'bpmn-visualization';
 
 /** CSS class names applied to diagram elements to reflect execution state. */
@@ -27,13 +28,34 @@ export class BpmnFlowViewer {
   private readonly takenFlows = new Set<string>();
 
   constructor(options: ViewerOptions) {
-    this.visualization = new BpmnVisualization({ container: options.container });
+    this.visualization = new BpmnVisualization({
+      container: options.container,
+      // Bounded pan and zoom (mouse wheel / drag), like a constrained canvas.
+      navigation: { enabled: true },
+    });
   }
 
-  /** Loads and renders the BPMN diagram, clearing any prior overlay state. */
-  load(xml: string): void {
-    this.visualization.load(xml, { fit: { type: FitType.Center } });
+  /**
+   * Loads and renders the BPMN diagram, clearing any prior overlay state.
+   *
+   * If the XML has no diagram interchange (no layout coordinates), a layout is
+   * computed automatically so processes authored purely in terms of semantics
+   * still render.
+   */
+  async load(xml: string): Promise<void> {
+    const renderable = hasDiagramInterchange(xml) ? xml : await this.layout(xml);
+    this.visualization.load(renderable, { fit: { type: FitType.Center } });
     this.takenFlows.clear();
+  }
+
+  private async layout(xml: string): Promise<string> {
+    try {
+      return await layoutProcess(xml);
+    } catch {
+      // Fall back to the original XML; bpmn-visualization will report if it
+      // truly cannot render.
+      return xml;
+    }
   }
 
   /** Fits the diagram to the viewport. */
@@ -117,6 +139,11 @@ export class BpmnFlowViewer {
       EXECUTION_CLASSES.taken,
     );
   }
+}
+
+/** True when the XML already carries diagram interchange (layout) data. */
+export function hasDiagramInterchange(xml: string): boolean {
+  return /BPMNDiagram|BPMNPlane|BPMNShape/.test(xml);
 }
 
 export type { ExecutionSnapshot, WorkflowEngine } from '@bpmn-flow/core';

--- a/packages/viewer/src/types/bpmn-auto-layout.d.ts
+++ b/packages/viewer/src/types/bpmn-auto-layout.d.ts
@@ -1,0 +1,8 @@
+/** Minimal ambient declaration for `bpmn-auto-layout`, which ships no types. */
+declare module 'bpmn-auto-layout' {
+  /**
+   * Computes diagram interchange (layout) for a BPMN process and returns new
+   * XML that includes BPMNDiagram/BPMNShape/BPMNEdge elements.
+   */
+  export function layoutProcess(xml: string): Promise<string>;
+}

--- a/packages/viewer/tsup.config.ts
+++ b/packages/viewer/tsup.config.ts
@@ -7,5 +7,5 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   treeshake: true,
-  external: ['bpmn-visualization', '@bpmn-flow/core'],
+  external: ['bpmn-visualization', 'bpmn-auto-layout', '@bpmn-flow/core'],
 });


### PR DESCRIPTION
## Contexto

O repositório era uma demo de navegador que nunca integrou um motor BPMN real:
bibliotecas de renderização "mock" feitas à mão, viewers duplicados,
`package.json` vazio, tooling Python/Poetry para um projeto TypeScript e exemplos
copiados. Esta PR reconstrói o projeto como uma biblioteca modular e reutilizável
de automação BPMN 2.0, com visualização interativa e um editor de diagramas.

## O que muda

Monorepo (npm workspaces) com quatro módulos:

- **`@bpmn-flow/core`** — parser BPMN 2.0 (`bpmn-moddle`) para um modelo normalizado
  e serializável + motor de execução por tokens. Reconhece todos os padrões:
  eventos (start/end/terminate/error/intermediate/boundary), definições
  message/timer/error/signal/escalation, todas as tasks com handlers plugáveis,
  subprocessos aninhados, call activities e gateways
  exclusivo/paralelo/inclusivo/baseado-em-evento/complexo. Inclui validação
  estrutural (`validateBpmn`). Isomórfico (Node e navegador).
- **`@bpmn-flow/viewer`** — render interativo sobre `bpmn-visualization` com overlays
  de execução ao vivo (nós concluídos, tokens ativos, esperas, fluxos percorridos),
  navegação (pan/zoom) e auto-layout via `bpmn-auto-layout` quando o diagrama não
  tem DI.
- **`@bpmn-flow/server`** — API REST (Hono) + host estático com CLI `bpmn-flow-serve`.
  Sessões de execução em memória para dirigir um processo passo a passo por HTTP;
  endpoints de validação e de salvar diagramas no diretório de exemplos.
- **`@bpmn-flow/playground`** — app Vite com dois modos: **Executar** (visualiza e roda
  o processo no navegador, interativo ou automático) e **Editar** (editor `bpmn-js`
  para criar/editar, validar e salvar `.bpmn` no repositório).

## Como foi verificado

- 27 testes Vitest cobrindo o parser e cada padrão de execução do motor.
- `typecheck`, ESLint e `build` limpos em todo o monorepo.
- Motor validado em runtime contra os diagramas de exemplo (todos completam sem
  tokens residuais).
- Server exercitado por HTTP (health, samples, sessão, validate, save, erro 400,
  rejeição de nome inseguro).
- Playground verificado no navegador na porta 3000: execução completa com caminho
  destacado, step-through interativo pausando em user task, e um save real de um
  diagrama criado no editor para `bpmn-files/`.

## Notas para revisão

- Commits atômicos e separados por camada, na ordem de construção.
- `package.json`/`README` referenciam `Bappoz` e licença MIT com autoria genérica —
  ajustar autor/e-mail antes de publicar os pacotes no npm.
- Limitações conhecidas documentadas em `docs/ARCHITECTURE.md` (timers avançam via
  `signal` ou modo auto; call activities externas são pass-through; junção inclusiva
  usa alcançabilidade estrutural).
