### PR TITLE
fix: ordem de build no CI e setas faltando nos diagramas

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,7 @@ jobs:
           BASE_PATH: /${{ github.event.repository.name }}/
         run: npm run build
 
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: apps/playground/dist
 
@@ -47,4 +47,4 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -433,8 +433,14 @@ npm run format      # Prettier
 npm run dev         # sobe o playground em modo de desenvolvimento
 ```
 
-O CI roda `build`, `format:check`, `lint`, `typecheck` e `test` no Node 20 e 22
-(o build vem primeiro porque os pacotes se checam pelos tipos gerados).
+```bash
+npm run verify      # build + format + lint + typecheck + test, falhando no primeiro erro
+```
+
+`verify` é exatamente o que o CI roda, na mesma ordem — o build vem primeiro
+porque os pacotes se checam pelos tipos gerados uns dos outros, e os workspaces
+são compilados em ordem de dependência (`core` antes de quem o consome). O CI
+executa isso no Node 20 e 22.
 
 ### Publicando
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "apps/*"
   ],
   "scripts": {
-    "build": "npm run build --workspaces --if-present",
+    "build": "npm run build -w @bpmn-flow/core && npm run build -w @bpmn-flow/viewer && npm run build -w @bpmn-flow/server && npm run build -w @bpmn-flow/cli && npm run build -w @bpmn-flow/playground",
+    "verify": "npm run build && npm run format:check && npm run lint && npm run typecheck && npm test",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/core/test/gateways-events.test.ts
+++ b/packages/core/test/gateways-events.test.ts
@@ -14,42 +14,42 @@ describe('conditional event', () => {
     const eng = new WorkflowEngine(await process(CONDITIONAL_CATCH), {
       variables: { saldo: 20 },
     });
-    let snap = await eng.start();
+    const parked = await eng.start();
     // Both branches are parked: the user task and the conditional event.
-    expect(snap.tokens.filter((t) => t.waiting)).toHaveLength(2);
-    expect(snap.completedNodes).not.toContain('Liberar');
+    expect(parked.tokens.filter((t) => t.waiting)).toHaveLength(2);
+    expect(parked.completedNodes).not.toContain('Liberar');
 
     const deposit = eng.tasks({ nodeId: 'Depositar' })[0]!;
-    snap = await eng.completeTask(deposit.tokenId, { saldo: 150 });
+    const after = await eng.completeTask(deposit.tokenId, { saldo: 150 });
 
-    expect(snap.completedNodes).toContain('Liberar');
-    expect(snap.status).toBe('completed');
+    expect(after.completedNodes).toContain('Liberar');
+    expect(after.status).toBe('completed');
   });
 
   it('stays parked while the condition is false', async () => {
     const eng = new WorkflowEngine(await process(CONDITIONAL_CATCH), {
       variables: { saldo: 20 },
     });
-    let snap = await eng.start();
+    await eng.start();
     const deposit = eng.tasks({ nodeId: 'Depositar' })[0]!;
-    snap = await eng.completeTask(deposit.tokenId, { saldo: 30 });
+    const after = await eng.completeTask(deposit.tokenId, { saldo: 30 });
 
-    expect(snap.status).toBe('waiting');
-    expect(snap.tokens.filter((t) => t.waiting)).toHaveLength(1);
-    expect(snap.completedNodes).not.toContain('Liberar');
+    expect(after.status).toBe('waiting');
+    expect(after.tokens.filter((t) => t.waiting)).toHaveLength(1);
+    expect(after.completedNodes).not.toContain('Liberar');
   });
 });
 
 describe('complex gateway', () => {
   it('fires the join when the activation condition holds (quorum of 2)', async () => {
     const eng = new WorkflowEngine(await process(COMPLEX_GATEWAY));
-    let snap = await eng.start();
+    await eng.start();
     expect(eng.tasks()).toHaveLength(3);
 
-    snap = await eng.completeTask(eng.tasks({ nodeId: 'VotoA' })[0]!.tokenId);
-    expect(snap.completedNodes).not.toContain('Decidir');
+    const first = await eng.completeTask(eng.tasks({ nodeId: 'VotoA' })[0]!.tokenId);
+    expect(first.completedNodes).not.toContain('Decidir');
 
-    snap = await eng.completeTask(eng.tasks({ nodeId: 'VotoB' })[0]!.tokenId);
+    const snap = await eng.completeTask(eng.tasks({ nodeId: 'VotoB' })[0]!.tokenId);
     // Two of three arrived: quorum reached, the third is no longer required.
     expect(snap.completedNodes).toContain('Decidir');
   });
@@ -57,8 +57,7 @@ describe('complex gateway', () => {
 
 describe('an event with several definitions', () => {
   it('arms the timer and answers to the message name', async () => {
-    let now = T0;
-    const eng = new WorkflowEngine(await process(MULTI_EVENT_DEFINITIONS), { now: () => now });
+    const eng = new WorkflowEngine(await process(MULTI_EVENT_DEFINITIONS), { now: () => T0 });
     await eng.start();
     expect(eng.nextTimerAt()).toBe(T0 + 30 * 60_000);
 

--- a/packages/viewer/src/index.ts
+++ b/packages/viewer/src/index.ts
@@ -1,5 +1,5 @@
 import type { ActivityMetrics, ExecutionSnapshot, WorkflowEngine } from '@bpmn-flow/core';
-import { ExecutionReplay, type ReplayFrame } from './replay.js';
+import type { ReplayFrame } from './replay.js';
 import { layoutProcess } from 'bpmn-auto-layout';
 import { BpmnVisualization, FitType } from 'bpmn-visualization';
 


### PR DESCRIPTION
Dois defeitos, ambos meus.

## 1. CI vermelho (Node 20, Node 22 e Demo)

`npm run build` era `npm run build --workspaces --if-present`, e o npm expande `packages/*` em ordem alfabética: **cli** vinha antes de **core**, então o build de tipos da CLI não achava `@bpmn-flow/core` (TS2307). Localmente passava porque `packages/core/dist` sobrava de execuções anteriores. O `Demo / Deploy` só ficou *skipped* porque o `Demo / build` morria antes.

- Build encadeia os workspaces na ordem de dependência: core → viewer → server → cli → playground.
- Quatro erros de lint que também estavam vermelhos (import não usado, duas atribuições inúteis, um `prefer-const`).
- Actions do Pages no major atual (`upload-pages-artifact@v5`, `deploy-pages@v5`).
- Novo `npm run verify`: build + format + lint + typecheck + test na ordem do CI, falhando no primeiro erro.

## 2. Diagramas sem seta entre as tarefas

`bpmn-auto-layout` monta o grafo pelos elementos `<bpmn:incoming>`/`<bpmn:outgoing>` de cada nó — não pelos `sourceRef`/`targetRef` do fluxo. Os diagramas que gerei só tinham os segundos, então o layout posicionava as caixas e não emitia **nenhum** `BPMNEdge`.

| XML | shapes | edges |
| --- | --- | --- |
| só `sourceRef`/`targetRef` | 6 | 0 |
| com `<bpmn:incoming>`/`<bpmn:outgoing>` | 6 | 4 |

- `@bpmn-flow/core` exporta `addFlowReferences(xml)`, que escreve essa ligação redundante de volta no XML.
- `ensureLayout()` chama isso antes de posicionar, então qualquer diagrama semântico passa a renderizar com as conexões.
- Os 4 exemplos gerados foram refeitos pelo pipeline corrigido (modelo parseado idêntico — muda só o layout).
- `ensureLayout`/`hasDiagramInterchange` foram para um módulo próprio, sem dependência de renderização, e um teste percorre **todos** os `.bpmn` do repositório exigindo uma aresta por fluxo de sequência.

## Verificação

`npm ci` do zero + `npm run verify`: exit 0, 148 testes em 22 arquivos. Conferido também no navegador: os diagramas de compensação e de SLA agora desenham as setas e o evento de borda.