### PR TITLE
fix(viewer): desenhar as setas em diagramas sem layout

### DIFF
--- a/bpmn-files/processo-aprovacao-coletiva.bpmn
+++ b/bpmn-files/processo-aprovacao-coletiva.bpmn
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_Aprovacao" targetNamespace="http://bpmn-flow">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_Aprovacao" targetNamespace="http://bpmn-flow">
   <bpmn:process id="Process_Aprovacao" name="Aprovação Coletiva" isExecutable="true">
     <bpmn:dataObject id="aprovadores" name="aprovadores" />
     <bpmn:dataObject id="votos" name="votos" />
-    <bpmn:startEvent id="PropostaRecebida" name="Proposta Recebida" />
+    <bpmn:startEvent id="PropostaRecebida" name="Proposta Recebida">
+      <bpmn:outgoing>f0</bpmn:outgoing>
+    </bpmn:startEvent>
     <bpmn:userTask id="Aprovar" name="Aprovar Proposta">
+      <bpmn:incoming>f0</bpmn:incoming>
+      <bpmn:outgoing>f1</bpmn:outgoing>
       <bpmn:potentialOwner>
         <bpmn:resourceAssignmentExpression>
           <bpmn:expression xsi:type="bpmn:tFormalExpression">comite</bpmn:expression>
@@ -17,8 +21,13 @@
         <bpmn:outputDataItem id="voto" name="voto" />
       </bpmn:multiInstanceLoopCharacteristics>
     </bpmn:userTask>
-    <bpmn:serviceTask id="Consolidar" name="Consolidar Votos" />
-    <bpmn:endEvent id="DecisaoTomada" name="Decisão Tomada" />
+    <bpmn:serviceTask id="Consolidar" name="Consolidar Votos">
+      <bpmn:incoming>f1</bpmn:incoming>
+      <bpmn:outgoing>f2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="DecisaoTomada" name="Decisão Tomada">
+      <bpmn:incoming>f2</bpmn:incoming>
+    </bpmn:endEvent>
     <bpmn:sequenceFlow id="f0" sourceRef="PropostaRecebida" targetRef="Aprovar" />
     <bpmn:sequenceFlow id="f1" sourceRef="Aprovar" targetRef="Consolidar" />
     <bpmn:sequenceFlow id="f2" sourceRef="Consolidar" targetRef="DecisaoTomada" />
@@ -35,14 +44,26 @@
         <dc:Bounds x="57" y="332" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Aprovar_di" bpmnElement="Aprovar">
-        <dc:Bounds x="25" y="450" width="100" height="80" />
+        <dc:Bounds x="175" y="310" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Consolidar_di" bpmnElement="Consolidar">
-        <dc:Bounds x="25" y="590" width="100" height="80" />
+        <dc:Bounds x="325" y="310" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="DecisaoTomada_di" bpmnElement="DecisaoTomada">
-        <dc:Bounds x="57" y="752" width="36" height="36" />
+        <dc:Bounds x="507" y="332" width="36" height="36" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="f0_di" bpmnElement="f0">
+        <di:waypoint x="93" y="350" />
+        <di:waypoint x="175" y="350" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f1_di" bpmnElement="f1">
+        <di:waypoint x="275" y="350" />
+        <di:waypoint x="325" y="350" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f2_di" bpmnElement="f2">
+        <di:waypoint x="425" y="350" />
+        <di:waypoint x="507" y="350" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/bpmn-files/processo-pedido-itens.bpmn
+++ b/bpmn-files/processo-pedido-itens.bpmn
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_Pedido" targetNamespace="http://bpmn-flow">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_Pedido" targetNamespace="http://bpmn-flow">
   <bpmn:process id="Process_Pedido" name="Processo de Pedido" isExecutable="true">
     <bpmn:dataObject id="itens" name="itens" />
     <bpmn:dataObject id="separados" name="separados" />
-    <bpmn:startEvent id="PedidoRecebido" name="Pedido Recebido" />
+    <bpmn:startEvent id="PedidoRecebido" name="Pedido Recebido">
+      <bpmn:outgoing>f0</bpmn:outgoing>
+    </bpmn:startEvent>
     <bpmn:serviceTask id="SepararItem" name="Separar Item">
+      <bpmn:incoming>f0</bpmn:incoming>
+      <bpmn:outgoing>f1</bpmn:outgoing>
       <bpmn:multiInstanceLoopCharacteristics>
         <bpmn:loopDataInputRef>itens</bpmn:loopDataInputRef>
         <bpmn:loopDataOutputRef>separados</bpmn:loopDataOutputRef>
@@ -12,10 +16,23 @@
         <bpmn:outputDataItem id="separado" name="separado" />
       </bpmn:multiInstanceLoopCharacteristics>
     </bpmn:serviceTask>
-    <bpmn:exclusiveGateway id="PrecisaConferencia" name="Precisa conferência?" default="fDireto" />
-    <bpmn:userTask id="ConferirPedido" name="Conferir Pedido" />
-    <bpmn:serviceTask id="EmitirNota" name="Emitir Nota Fiscal" />
-    <bpmn:endEvent id="PedidoEnviado" name="Pedido Enviado" />
+    <bpmn:exclusiveGateway id="PrecisaConferencia" name="Precisa conferência?" default="fDireto">
+      <bpmn:incoming>f1</bpmn:incoming>
+      <bpmn:outgoing>fConferir</bpmn:outgoing>
+      <bpmn:outgoing>fDireto</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="ConferirPedido" name="Conferir Pedido">
+      <bpmn:incoming>fConferir</bpmn:incoming>
+      <bpmn:outgoing>f2</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:serviceTask id="EmitirNota" name="Emitir Nota Fiscal">
+      <bpmn:incoming>fDireto</bpmn:incoming>
+      <bpmn:incoming>f2</bpmn:incoming>
+      <bpmn:outgoing>f3</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="PedidoEnviado" name="Pedido Enviado">
+      <bpmn:incoming>f3</bpmn:incoming>
+    </bpmn:endEvent>
     <bpmn:sequenceFlow id="f0" sourceRef="PedidoRecebido" targetRef="SepararItem" />
     <bpmn:sequenceFlow id="f1" sourceRef="SepararItem" targetRef="PrecisaConferencia" />
     <bpmn:sequenceFlow id="fConferir" name="Sim" sourceRef="PrecisaConferencia" targetRef="ConferirPedido">
@@ -37,20 +54,46 @@
         <dc:Bounds x="57" y="332" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="SepararItem_di" bpmnElement="SepararItem">
-        <dc:Bounds x="25" y="450" width="100" height="80" />
+        <dc:Bounds x="175" y="310" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="PrecisaConferencia_di" bpmnElement="PrecisaConferencia" isMarkerVisible="true">
-        <dc:Bounds x="50" y="605" width="50" height="50" />
+        <dc:Bounds x="350" y="325" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ConferirPedido_di" bpmnElement="ConferirPedido">
-        <dc:Bounds x="25" y="730" width="100" height="80" />
+        <dc:Bounds x="475" y="310" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EmitirNota_di" bpmnElement="EmitirNota">
-        <dc:Bounds x="25" y="870" width="100" height="80" />
+        <dc:Bounds x="625" y="310" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="PedidoEnviado_di" bpmnElement="PedidoEnviado">
-        <dc:Bounds x="57" y="1032" width="36" height="36" />
+        <dc:Bounds x="807" y="332" width="36" height="36" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="f0_di" bpmnElement="f0">
+        <di:waypoint x="93" y="350" />
+        <di:waypoint x="175" y="350" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f1_di" bpmnElement="f1">
+        <di:waypoint x="275" y="350" />
+        <di:waypoint x="350" y="350" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="fConferir_di" bpmnElement="fConferir">
+        <di:waypoint x="400" y="350" />
+        <di:waypoint x="475" y="350" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="fDireto_di" bpmnElement="fDireto">
+        <di:waypoint x="375" y="375" />
+        <di:waypoint x="375" y="420" />
+        <di:waypoint x="675" y="420" />
+        <di:waypoint x="675" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f2_di" bpmnElement="f2">
+        <di:waypoint x="575" y="350" />
+        <di:waypoint x="625" y="350" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f3_di" bpmnElement="f3">
+        <di:waypoint x="725" y="350" />
+        <di:waypoint x="807" y="350" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/bpmn-files/processo-suporte-sla.bpmn
+++ b/bpmn-files/processo-suporte-sla.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_Sla" targetNamespace="http://bpmn-flow">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_Sla" targetNamespace="http://bpmn-flow">
   <bpmn:process id="Process_Sla" name="Atendimento com SLA" isExecutable="true">
     <bpmn:laneSet id="Lanes">
       <bpmn:lane id="LaneSuporte" name="Suporte">
@@ -13,8 +13,12 @@
         <bpmn:flowNodeRef>ChamadoEscalado</bpmn:flowNodeRef>
       </bpmn:lane>
     </bpmn:laneSet>
-    <bpmn:startEvent id="ChamadoAberto" name="Chamado Aberto" />
+    <bpmn:startEvent id="ChamadoAberto" name="Chamado Aberto">
+      <bpmn:outgoing>f0</bpmn:outgoing>
+    </bpmn:startEvent>
     <bpmn:userTask id="Atender" name="Atender Chamado">
+      <bpmn:incoming>f0</bpmn:incoming>
+      <bpmn:outgoing>f1</bpmn:outgoing>
       <bpmn:potentialOwner>
         <bpmn:resourceAssignmentExpression>
           <bpmn:expression xsi:type="bpmn:tFormalExpression">suporte-n1</bpmn:expression>
@@ -22,19 +26,26 @@
       </bpmn:potentialOwner>
     </bpmn:userTask>
     <bpmn:boundaryEvent id="PrazoEstourado" name="2h" attachedToRef="Atender">
+      <bpmn:outgoing>fb</bpmn:outgoing>
       <bpmn:timerEventDefinition>
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT2H</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
     <bpmn:userTask id="Escalar" name="Escalar para Gerência">
+      <bpmn:incoming>fb</bpmn:incoming>
+      <bpmn:outgoing>fb2</bpmn:outgoing>
       <bpmn:potentialOwner>
         <bpmn:resourceAssignmentExpression>
           <bpmn:expression xsi:type="bpmn:tFormalExpression">gerentes</bpmn:expression>
         </bpmn:resourceAssignmentExpression>
       </bpmn:potentialOwner>
     </bpmn:userTask>
-    <bpmn:endEvent id="ChamadoResolvido" name="Chamado Resolvido" />
-    <bpmn:endEvent id="ChamadoEscalado" name="Chamado Escalado" />
+    <bpmn:endEvent id="ChamadoResolvido" name="Chamado Resolvido">
+      <bpmn:incoming>f1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="ChamadoEscalado" name="Chamado Escalado">
+      <bpmn:incoming>fb2</bpmn:incoming>
+    </bpmn:endEvent>
     <bpmn:sequenceFlow id="f0" sourceRef="ChamadoAberto" targetRef="Atender" />
     <bpmn:sequenceFlow id="f1" sourceRef="Atender" targetRef="ChamadoResolvido" />
     <bpmn:sequenceFlow id="fb" sourceRef="PrazoEstourado" targetRef="Escalar" />
@@ -46,20 +57,37 @@
         <dc:Bounds x="57" y="52" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Atender_di" bpmnElement="Atender">
-        <dc:Bounds x="25" y="170" width="100" height="80" />
+        <dc:Bounds x="175" y="30" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="PrazoEstourado_di" bpmnElement="PrazoEstourado">
-        <dc:Bounds x="57" y="232" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Escalar_di" bpmnElement="Escalar">
-        <dc:Bounds x="25" y="310" width="100" height="80" />
+        <dc:Bounds x="207" y="92" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ChamadoResolvido_di" bpmnElement="ChamadoResolvido">
-        <dc:Bounds x="57" y="472" width="36" height="36" />
+        <dc:Bounds x="357" y="52" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Escalar_di" bpmnElement="Escalar">
+        <dc:Bounds x="325" y="170" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ChamadoEscalado_di" bpmnElement="ChamadoEscalado">
-        <dc:Bounds x="57" y="612" width="36" height="36" />
+        <dc:Bounds x="507" y="192" width="36" height="36" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="f0_di" bpmnElement="f0">
+        <di:waypoint x="93" y="70" />
+        <di:waypoint x="175" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f1_di" bpmnElement="f1">
+        <di:waypoint x="275" y="70" />
+        <di:waypoint x="357" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="fb_di" bpmnElement="fb">
+        <di:waypoint x="225" y="128" />
+        <di:waypoint x="225" y="210" />
+        <di:waypoint x="325" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="fb2_di" bpmnElement="fb2">
+        <di:waypoint x="425" y="210" />
+        <di:waypoint x="507" y="210" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/bpmn-files/processo-viagem-compensacao.bpmn
+++ b/bpmn-files/processo-viagem-compensacao.bpmn
@@ -1,23 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_Viagem" targetNamespace="http://bpmn-flow">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_Viagem" targetNamespace="http://bpmn-flow">
   <bpmn:process id="Process_Viagem" name="Reserva de Viagem" isExecutable="true">
-    <bpmn:startEvent id="ViagemSolicitada" name="Viagem Solicitada" />
-    <bpmn:serviceTask id="ReservarVoo" name="Reservar Voo" />
+    <bpmn:startEvent id="ViagemSolicitada" name="Viagem Solicitada">
+      <bpmn:outgoing>f0</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="ReservarVoo" name="Reservar Voo">
+      <bpmn:incoming>f0</bpmn:incoming>
+      <bpmn:outgoing>f1</bpmn:outgoing>
+    </bpmn:serviceTask>
     <bpmn:boundaryEvent id="CompVoo" attachedToRef="ReservarVoo">
       <bpmn:compensateEventDefinition />
     </bpmn:boundaryEvent>
     <bpmn:serviceTask id="CancelarVoo" name="Cancelar Voo" isForCompensation="true" />
-    <bpmn:serviceTask id="ReservarHotel" name="Reservar Hotel" />
+    <bpmn:serviceTask id="ReservarHotel" name="Reservar Hotel">
+      <bpmn:incoming>f1</bpmn:incoming>
+      <bpmn:outgoing>f2</bpmn:outgoing>
+    </bpmn:serviceTask>
     <bpmn:boundaryEvent id="CompHotel" attachedToRef="ReservarHotel">
       <bpmn:compensateEventDefinition />
     </bpmn:boundaryEvent>
     <bpmn:serviceTask id="CancelarHotel" name="Cancelar Hotel" isForCompensation="true" />
-    <bpmn:exclusiveGateway id="PagamentoOk" name="Pagamento aprovado?" default="fFalhou" />
-    <bpmn:endEvent id="ViagemConfirmada" name="Viagem Confirmada" />
+    <bpmn:exclusiveGateway id="PagamentoOk" name="Pagamento aprovado?" default="fFalhou">
+      <bpmn:incoming>f2</bpmn:incoming>
+      <bpmn:outgoing>fOk</bpmn:outgoing>
+      <bpmn:outgoing>fFalhou</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:endEvent id="ViagemConfirmada" name="Viagem Confirmada">
+      <bpmn:incoming>fOk</bpmn:incoming>
+    </bpmn:endEvent>
     <bpmn:intermediateThrowEvent id="DesfazerReservas" name="Desfazer Reservas">
+      <bpmn:incoming>fFalhou</bpmn:incoming>
+      <bpmn:outgoing>f3</bpmn:outgoing>
       <bpmn:compensateEventDefinition />
     </bpmn:intermediateThrowEvent>
-    <bpmn:endEvent id="ViagemCancelada" name="Viagem Cancelada" />
+    <bpmn:endEvent id="ViagemCancelada" name="Viagem Cancelada">
+      <bpmn:incoming>f3</bpmn:incoming>
+    </bpmn:endEvent>
     <bpmn:sequenceFlow id="f0" sourceRef="ViagemSolicitada" targetRef="ReservarVoo" />
     <bpmn:sequenceFlow id="f1" sourceRef="ReservarVoo" targetRef="ReservarHotel" />
     <bpmn:sequenceFlow id="f2" sourceRef="ReservarHotel" targetRef="PagamentoOk" />
@@ -35,35 +53,60 @@
         <dc:Bounds x="57" y="52" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ReservarVoo_di" bpmnElement="ReservarVoo">
-        <dc:Bounds x="25" y="170" width="100" height="80" />
+        <dc:Bounds x="175" y="30" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="CompVoo_di" bpmnElement="CompVoo">
-        <dc:Bounds x="57" y="232" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="CancelarVoo_di" bpmnElement="CancelarVoo">
-        <dc:Bounds x="25" y="310" width="100" height="80" />
+        <dc:Bounds x="207" y="92" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ReservarHotel_di" bpmnElement="ReservarHotel">
-        <dc:Bounds x="25" y="450" width="100" height="80" />
+        <dc:Bounds x="325" y="30" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="CompHotel_di" bpmnElement="CompHotel">
-        <dc:Bounds x="57" y="512" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="CancelarHotel_di" bpmnElement="CancelarHotel">
-        <dc:Bounds x="25" y="590" width="100" height="80" />
+        <dc:Bounds x="357" y="92" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="PagamentoOk_di" bpmnElement="PagamentoOk" isMarkerVisible="true">
-        <dc:Bounds x="50" y="745" width="50" height="50" />
+        <dc:Bounds x="500" y="45" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ViagemConfirmada_di" bpmnElement="ViagemConfirmada">
-        <dc:Bounds x="57" y="892" width="36" height="36" />
+        <dc:Bounds x="657" y="52" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CancelarVoo_di" bpmnElement="CancelarVoo">
+        <dc:Bounds x="25" y="170" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="DesfazerReservas_di" bpmnElement="DesfazerReservas">
-        <dc:Bounds x="57" y="1032" width="36" height="36" />
+        <dc:Bounds x="657" y="192" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ViagemCancelada_di" bpmnElement="ViagemCancelada">
-        <dc:Bounds x="57" y="1172" width="36" height="36" />
+        <dc:Bounds x="807" y="192" width="36" height="36" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CancelarHotel_di" bpmnElement="CancelarHotel">
+        <dc:Bounds x="25" y="310" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="f0_di" bpmnElement="f0">
+        <di:waypoint x="93" y="70" />
+        <di:waypoint x="175" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f1_di" bpmnElement="f1">
+        <di:waypoint x="275" y="70" />
+        <di:waypoint x="325" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f2_di" bpmnElement="f2">
+        <di:waypoint x="425" y="70" />
+        <di:waypoint x="500" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="fOk_di" bpmnElement="fOk">
+        <di:waypoint x="550" y="70" />
+        <di:waypoint x="657" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="fFalhou_di" bpmnElement="fFalhou">
+        <di:waypoint x="525" y="95" />
+        <di:waypoint x="525" y="210" />
+        <di:waypoint x="657" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f3_di" bpmnElement="f3">
+        <di:waypoint x="693" y="210" />
+        <di:waypoint x="807" y="210" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,6 +38,11 @@ derivado dos próprios fluxos de sequência, e não dos arrays opcionais do nó,
 tornando o parsing robusto a diagramas inconsistentes. Subprocessos são lidos
 recursivamente como escopos aninhados.
 
+O contrário também existe: `addFlowReferences` escreve de volta o
+`<bpmn:incoming>`/`<bpmn:outgoing>` de cada nó. É redundante para o motor, mas
+o resto do ecossistema lê só esses elementos — o `bpmn-auto-layout` posiciona as
+caixas e não desenha aresta nenhuma sem eles.
+
 ### Motor (`@bpmn-flow/core/engine`)
 
 Execução por tokens. Um token representa uma linha de controle posicionada em um

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -22,6 +22,14 @@ fluxos de sequência com condições e colaboração. A interchange de diagrama 
 
 Lança `BpmnParseError` para XML inválido ou sem processo.
 
+### `addFlowReferences(xml): Promise<string>`
+
+Devolve o mesmo XML com o `<bpmn:incoming>`/`<bpmn:outgoing>` de cada nó
+preenchido a partir dos `sourceRef`/`targetRef` dos fluxos. O motor não precisa
+disso (deriva tudo dos fluxos), mas ferramentas do ecossistema leem só esses
+elementos — o `bpmn-auto-layout`, por exemplo, não desenha nenhuma aresta quando
+eles faltam. Idempotente.
+
 ### `validateBpmn(xml): Promise<ValidationResult>`
 
 Valida a estrutura do diagrama (processo sem evento de início ou de fim, nós

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export * from './model/kinds.js';
 export * from './model/types.js';
 export { ProcessGraph } from './model/graph.js';
 export { parseBpmn } from './parser/parse.js';
+export { addFlowReferences } from './parser/references.js';
 export { validateBpmn, validateModel } from './validate.js';
 export type { ValidationIssue, ValidationResult } from './validate.js';
 export { WorkflowEngine } from './engine/engine.js';

--- a/packages/core/src/parser/moddle-types.ts
+++ b/packages/core/src/parser/moddle-types.ts
@@ -64,6 +64,8 @@ export interface MdElement {
   $type: string;
   id?: string;
   name?: string;
+  /** Diagram interchange, when the file carries layout. */
+  diagrams?: unknown[];
 
   // bpmn:Definitions
   rootElements?: MdElement[];

--- a/packages/core/src/parser/references.ts
+++ b/packages/core/src/parser/references.ts
@@ -1,0 +1,73 @@
+import { BpmnModdle } from 'bpmn-moddle';
+import { BpmnParseError } from '../errors.js';
+import type { MdElement } from './moddle-types.js';
+
+/**
+ * BPMN states the wiring twice: a sequence flow points at its `sourceRef` and
+ * `targetRef`, and each flow node repeats it as `<bpmn:incoming>` /
+ * `<bpmn:outgoing>` children. The second half is redundant — this parser
+ * derives everything from the flows themselves — but tooling around the format
+ * often reads only those child elements. `bpmn-auto-layout`, for one, positions
+ * the nodes and draws no connection at all when they are missing.
+ *
+ * {@link addFlowReferences} fills them in, so a diagram authored purely in
+ * terms of semantics survives a round trip through those tools.
+ */
+
+interface ModdleElement extends MdElement {
+  flowElements?: ModdleElement[];
+  incoming?: ModdleElement[];
+  outgoing?: ModdleElement[];
+}
+
+/**
+ * Returns the same XML with each flow node's `incoming`/`outgoing` references
+ * spelled out, deriving them from the sequence flows of the scope. Nodes that
+ * already declare them are left untouched, so calling this twice is a no-op.
+ *
+ * @throws {BpmnParseError} when the XML cannot be read.
+ */
+export async function addFlowReferences(xml: string): Promise<string> {
+  const moddle = new BpmnModdle();
+  let definitions: ModdleElement;
+  try {
+    const { rootElement } = await moddle.fromXML(xml);
+    definitions = rootElement as ModdleElement;
+  } catch (cause) {
+    throw new BpmnParseError(
+      `Failed to parse BPMN XML: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+
+  for (const root of definitions.rootElements ?? []) {
+    if (root.$type.endsWith(':Process')) linkScope(root as ModdleElement);
+  }
+
+  const { xml: serialized } = await moddle.toXML(definitions, { format: true });
+  return serialized ?? xml;
+}
+
+/** Wires one scope (process or subprocess) and recurses into nested ones. */
+function linkScope(scope: ModdleElement): void {
+  const elements = scope.flowElements ?? [];
+  const byId = new Map<string, ModdleElement>();
+  for (const element of elements) {
+    if (element.id) byId.set(element.id, element);
+    if (element.flowElements && element.flowElements.length > 0) linkScope(element);
+  }
+
+  for (const element of elements) {
+    if (!element.$type.endsWith(':SequenceFlow')) continue;
+    const source = element.sourceRef?.id ? byId.get(element.sourceRef.id) : undefined;
+    const target = element.targetRef?.id ? byId.get(element.targetRef.id) : undefined;
+    if (source) push(source, 'outgoing', element);
+    if (target) push(target, 'incoming', element);
+  }
+}
+
+/** Adds the flow to the node's reference list, without duplicating it. */
+function push(node: ModdleElement, key: 'incoming' | 'outgoing', flow: ModdleElement): void {
+  const current = node[key] ?? [];
+  if (current.some((existing) => existing.id === flow.id)) return;
+  node[key] = [...current, flow];
+}

--- a/packages/core/test/references.test.ts
+++ b/packages/core/test/references.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { addFlowReferences, parseBpmn } from '../src/index.js';
+
+const SEM_REFS = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  targetNamespace="http://bpmn-flow.test" id="Defs">
+  <bpmn:process id="P" isExecutable="true">
+    <bpmn:startEvent id="Start" />
+    <bpmn:subProcess id="Sub">
+      <bpmn:startEvent id="SubStart" />
+      <bpmn:task id="Inner" />
+      <bpmn:endEvent id="SubEnd" />
+      <bpmn:sequenceFlow id="s1" sourceRef="SubStart" targetRef="Inner" />
+      <bpmn:sequenceFlow id="s2" sourceRef="Inner" targetRef="SubEnd" />
+    </bpmn:subProcess>
+    <bpmn:endEvent id="End" />
+    <bpmn:sequenceFlow id="f0" sourceRef="Start" targetRef="Sub" />
+    <bpmn:sequenceFlow id="f1" sourceRef="Sub" targetRef="End" />
+  </bpmn:process>
+</bpmn:definitions>`;
+
+describe('addFlowReferences', () => {
+  it('spells out the wiring the sequence flows already describe', async () => {
+    expect(SEM_REFS).not.toContain('<bpmn:incoming>');
+
+    const wired = await addFlowReferences(SEM_REFS);
+
+    expect(wired).toContain('<bpmn:outgoing>f0</bpmn:outgoing>');
+    expect(wired).toContain('<bpmn:incoming>f0</bpmn:incoming>');
+    expect(wired).toContain('<bpmn:incoming>f1</bpmn:incoming>');
+  });
+
+  it('reaches inside subprocesses', async () => {
+    const wired = await addFlowReferences(SEM_REFS);
+    expect(wired).toContain('<bpmn:outgoing>s1</bpmn:outgoing>');
+    expect(wired).toContain('<bpmn:incoming>s2</bpmn:incoming>');
+  });
+
+  it('is a no-op when the references are already there', async () => {
+    const once = await addFlowReferences(SEM_REFS);
+    const twice = await addFlowReferences(once);
+    const count = (xml: string): number => (xml.match(/<bpmn:incoming>/g) ?? []).length;
+    expect(count(twice)).toBe(count(once));
+  });
+
+  it('keeps the model identical for the engine', async () => {
+    const before = await parseBpmn(SEM_REFS);
+    const after = await parseBpmn(await addFlowReferences(SEM_REFS));
+    expect(after.processes[0]?.flowNodes.map((n) => n.id)).toEqual(
+      before.processes[0]?.flowNodes.map((n) => n.id),
+    );
+    expect(after.processes[0]?.sequenceFlows).toEqual(before.processes[0]?.sequenceFlows);
+  });
+
+  it('rejects XML it cannot read', async () => {
+    await expect(addFlowReferences('<nope')).rejects.toThrow(/Failed to parse/);
+  });
+});

--- a/packages/viewer/README.md
+++ b/packages/viewer/README.md
@@ -25,6 +25,10 @@ viewer.load(xml);
 
 - `load(xml)`: renderiza o diagrama e centraliza. Diagramas sem layout (sem DI)
   são posicionados automaticamente com `bpmn-auto-layout`.
+- `ensureLayout(xml)` / `hasDiagramInterchange(xml)`: o mesmo posicionamento,
+  disponível isolado para quem precisa de DI (o editor `bpmn-js`, por exemplo).
+  Antes de posicionar, explicita as referências de fluxo com
+  `addFlowReferences` — sem isso o layout desenha as caixas e **nenhuma seta**.
 - `fit()`: ajusta o diagrama ao viewport.
 - `applySnapshot(snapshot)`: aplica um `ExecutionSnapshot` como fonte de verdade
   (nós concluídos, tokens ativos e atividades em espera).

--- a/packages/viewer/src/index.ts
+++ b/packages/viewer/src/index.ts
@@ -1,6 +1,6 @@
 import type { ActivityMetrics, ExecutionSnapshot, WorkflowEngine } from '@bpmn-flow/core';
 import type { ReplayFrame } from './replay.js';
-import { layoutProcess } from 'bpmn-auto-layout';
+import { ensureLayout } from './layout.js';
 import { BpmnVisualization, FitType } from 'bpmn-visualization';
 
 /** CSS class names applied to diagram elements to reflect execution state. */
@@ -181,24 +181,6 @@ export class BpmnFlowViewer {
   }
 }
 
-/** True when the XML already carries diagram interchange (layout) data. */
-export function hasDiagramInterchange(xml: string): boolean {
-  return /BPMNDiagram|BPMNPlane|BPMNShape/.test(xml);
-}
-
-/**
- * Returns XML that is guaranteed to carry diagram interchange.
- *
- * A diagram authored purely in terms of semantics (no layout) is positioned
- * with `bpmn-auto-layout`; anything that already has DI is returned untouched.
- * Useful for consumers that require DI, such as a `bpmn-js` modeler.
- *
- * @throws when the layout engine cannot process the XML.
- */
-export async function ensureLayout(xml: string): Promise<string> {
-  return hasDiagramInterchange(xml) ? xml : await layoutProcess(xml);
-}
-
 /** `1.5 s`, `2 min`, `3 h` — short enough for a diagram badge. */
 function formatDuration(entry: ActivityMetrics): string {
   const ms = entry.averageMs;
@@ -208,6 +190,7 @@ function formatDuration(entry: ActivityMetrics): string {
   return `${(ms / 3_600_000).toFixed(1)} h`;
 }
 
+export { ensureLayout, hasDiagramInterchange } from './layout.js';
 export { ExecutionReplay } from './replay.js';
 export type { ReplayFrame } from './replay.js';
 export type { ActivityMetrics, ExecutionSnapshot, WorkflowEngine } from '@bpmn-flow/core';

--- a/packages/viewer/src/layout.ts
+++ b/packages/viewer/src/layout.ts
@@ -1,0 +1,28 @@
+import { addFlowReferences } from '@bpmn-flow/core';
+import { layoutProcess } from 'bpmn-auto-layout';
+
+/**
+ * Layout helpers, deliberately free of any rendering dependency: they turn
+ * XML into XML, which keeps them testable outside a browser.
+ */
+
+/** True when the XML already carries diagram interchange (layout) data. */
+export function hasDiagramInterchange(xml: string): boolean {
+  return /BPMNDiagram|BPMNPlane|BPMNShape/.test(xml);
+}
+
+/**
+ * Returns XML that is guaranteed to carry diagram interchange.
+ *
+ * A diagram authored purely in terms of semantics (no layout) is positioned
+ * with `bpmn-auto-layout`; anything that already has DI is returned untouched.
+ * Useful for consumers that require DI, such as a `bpmn-js` modeler.
+ *
+ * @throws when the layout engine cannot process the XML.
+ */
+export async function ensureLayout(xml: string): Promise<string> {
+  if (hasDiagramInterchange(xml)) return xml;
+  // The layout engine reads each node's incoming/outgoing children: without
+  // them it places the shapes and draws no connection at all.
+  return await layoutProcess(await addFlowReferences(xml));
+}

--- a/packages/viewer/test/layout.test.ts
+++ b/packages/viewer/test/layout.test.ts
@@ -1,0 +1,64 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+// Imported directly: layout is pure XML work, with no rendering dependency.
+import { ensureLayout, hasDiagramInterchange } from '../src/layout.js';
+
+const SEM_LAYOUT = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  targetNamespace="http://bpmn-flow.test" id="Defs">
+  <bpmn:process id="P" isExecutable="true">
+    <bpmn:startEvent id="Start" />
+    <bpmn:task id="Fazer" />
+    <bpmn:endEvent id="End" />
+    <bpmn:sequenceFlow id="f0" sourceRef="Start" targetRef="Fazer" />
+    <bpmn:sequenceFlow id="f1" sourceRef="Fazer" targetRef="End" />
+  </bpmn:process>
+</bpmn:definitions>`;
+
+const count = (xml: string, tag: string): number => (xml.match(new RegExp(tag, 'g')) ?? []).length;
+
+/** Repository samples, which the viewer has to be able to draw. */
+const samplesDir = fileURLToPath(new URL('../../../bpmn-files', import.meta.url));
+
+describe('hasDiagramInterchange', () => {
+  it('tells a laid-out diagram from a purely semantic one', () => {
+    expect(hasDiagramInterchange(SEM_LAYOUT)).toBe(false);
+    expect(hasDiagramInterchange('<x><bpmndi:BPMNShape /></x>')).toBe(true);
+  });
+});
+
+describe('ensureLayout', () => {
+  it('draws the connections, not only the boxes', async () => {
+    const laid = await ensureLayout(SEM_LAYOUT);
+
+    expect(count(laid, 'BPMNShape')).toBeGreaterThan(0);
+    // The regression: the layout engine reads each node's incoming/outgoing
+    // children, so without them it used to emit shapes and no edge at all.
+    expect(count(laid, 'BPMNEdge')).toBeGreaterThan(0);
+    expect(count(laid, 'waypoint')).toBeGreaterThan(0);
+  });
+
+  it('leaves a diagram that already has layout untouched', async () => {
+    const laid = await ensureLayout(SEM_LAYOUT);
+    expect(await ensureLayout(laid)).toBe(laid);
+  });
+});
+
+describe('the shipped samples', () => {
+  it('all render with their sequence flows', async () => {
+    const files = (await readdir(samplesDir)).filter((name) => name.endsWith('.bpmn'));
+    expect(files.length).toBeGreaterThan(0);
+
+    for (const file of files) {
+      const xml = await readFile(join(samplesDir, file), 'utf8');
+      const flows = count(xml, '<bpmn:sequenceFlow');
+      const laid = await ensureLayout(xml);
+      expect(
+        count(laid, 'BPMNEdge'),
+        `${file} deveria desenhar ${flows} fluxo(s)`,
+      ).toBeGreaterThanOrEqual(flows);
+    }
+  });
+});


### PR DESCRIPTION
O que você viu: os diagramas aparecem, mas **sem as linhas entre as tarefas**.

## Causa

`bpmn-auto-layout` monta o grafo pelos elementos `<bpmn:incoming>`/`<bpmn:outgoing>` dentro de cada nó — **não** pelos `sourceRef`/`targetRef` do fluxo de sequência. Os quatro diagramas que gerei declaravam só os segundos, então o layout posicionava as caixas e não emitia nenhum `BPMNEdge`.

| XML | shapes | edges |
| --- | --- | --- |
| só `sourceRef`/`targetRef` | 6 | **0** |
| com `<bpmn:incoming>`/`<bpmn:outgoing>` | 6 | **4** |

Os exemplos originais do repositório (`processo-compras`, `processo-simples`, `processo-gestao-projeto`) sempre desenharam certo porque foram escritos por ferramentas que emitem esses elementos.

## Correção

- `@bpmn-flow/core` passa a exportar `addFlowReferences(xml)`: escreve de volta a ligação redundante que o resto do ecossistema espera. Idempotente, e o modelo parseado continua idêntico.
- `ensureLayout()` chama isso antes de posicionar — então **qualquer** diagrama puramente semântico passa a renderizar com as conexões, não só os exemplos do repo.
- Os 4 exemplos gerados foram refeitos pelo pipeline corrigido (nós e fluxos idênticos; muda só o layout).
- `ensureLayout`/`hasDiagramInterchange` foram para `packages/viewer/src/layout.ts`, sem dependência de renderização, e agora têm teste.
- Um teste percorre **todos** os `.bpmn` do repositório exigindo ao menos uma aresta por fluxo de sequência — essa regressão não volta em silêncio.

## Verificação

`npm ci` do zero + `npm run verify`: exit 0, **148 testes em 22 arquivos**. Conferido no navegador: compensação (voo → hotel → gateway → dois fins) e SLA (timer de borda → escalar) desenham as setas.