### PR TITLE
feat: painel retrátil, variáveis sugeridas e os últimos itens do BPMN

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,25 @@ while ((frame = replay.next())) viewer.applyReplayFrame(frame);
 
 ![Tempo médio por atividade sobreposto ao diagrama](docs/media/metricas-por-atividade.png)
 
+## O diagrama diz quais variáveis ele precisa
+
+Um gateway com `pago === true` só abre com essa variável — e quem abre o
+processo pela primeira vez não tem como adivinhar. O core lê as expressões do
+próprio diagrama e responde:
+
+```ts
+processVariables(process);
+// [{ name: 'pago', kind: 'condition', expressions: ['pago === true'],
+//    usedBy: ['Pagamento aprovado?'], suggestion: true }]
+
+suggestVariables(process); // { pago: true, valor: 1001 }
+```
+
+A sugestão sai da forma da expressão (`valor > 1000` sugere 1001, `status ===
+"ok"` sugere `"ok"`, uma coleção de multi-instância sugere dois itens). O
+playground usa isso para já abrir a caixa de variáveis preenchida com algo que
+faz o processo andar, e lista cada variável com a expressão que a consome.
+
 ## Timers
 
 Eventos de timer viram data de vencimento. O motor não tem relógio próprio: ele
@@ -394,8 +413,13 @@ modo que reiniciar o servidor não perde execuções em andamento.
 - Sinais são **difundidos**: um `signal()` acorda todos os assinantes, inclusive
   receive tasks que esperam aquela mensagem.
 - Atividades: task, userTask, serviceTask, scriptTask, businessRuleTask,
-  sendTask, receiveTask, manualTask, subprocessos embutidos, **transaction** e
+  sendTask, receiveTask, manualTask, subprocessos embutidos, **transaction**,
+  **adHocSubProcess** (paralelo ou sequencial, com condição de conclusão) e
   **callActivity executando o processo referenciado**.
+- **Mapeamento de dados** de entrada e saída, que isola o processo chamado: ele
+  só enxerga o que foi mapeado, e só o mapeamento de saída volta.
+- Eventos de lançamento **entregam o gatilho** (sinal, mensagem, escalation,
+  compensação) para os assinantes do próprio processo.
 - Gateways: exclusivo (com fluxo default), paralelo (junção sincronizada),
   inclusivo (junção por alcançabilidade), baseado em evento e **complexo com
   condição de ativação** (quórum).
@@ -408,15 +432,13 @@ modo que reiniciar o servidor não perde execuções em andamento.
 
 ## Limitações conhecidas
 
-- **Ciclos de timer disparam uma vez**: `R3/PT10M` é lido como um intervalo de
-  10 minutos, sem repetição.
+- **Ciclos de timer repetem só em evento de borda não interrompente**
+  (`R3/PT1H` = três lembretes), que é onde repetir faz sentido.
 - **Expressões de condição são avaliadas como JavaScript** sobre as variáveis do
   processo, assumindo que a definição do diagrama é confiável. Variável
   inexistente lê como `undefined`; expressão que lança é tratada como `false`.
-- **Evento de borda condicional não é auto-avaliado** (o de captura é): dispare-o
-  por `signal()` pelo id.
-- **Mapeamento de dados** (`ioSpecification`, data associations de entrada/saída
-  em call activity) não é executado: o escopo filho enxerga as variáveis do pai.
+- **`ioSpecification` formal não é interpretado**: o mapeamento de dados é lido
+  na forma `assignment/from/to`.
 - **Correlação de mensagem por chave** não existe; a entrega é por nome da
   mensagem ou id do elemento.
 - **DMN está fora de escopo**: `businessRuleTask` é o ponto de extensão — ligue

--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -42,8 +42,13 @@ Há dois modos, alternados pelos botões "Executar" e "Editar".
 - O painel mostra status, variáveis e o histórico da execução; o diagrama
   destaca nós concluídos, tokens ativos, atividades em espera e fluxos
   percorridos.
-- "Reprisar" refaz a execução passo a passo a partir do histórico; "Métricas"
-  liga etiquetas de tempo médio em cada atividade.
+- "Run" refaz a execução passo a passo a partir do histórico; "Métricas" liga
+  etiquetas de tempo médio em cada atividade.
+- O painel **Variáveis do processo** lista o que o diagrama lê, com a expressão
+  que consome cada variável, e a caixa JSON já vem preenchida com valores que
+  fazem o processo andar.
+- O botão na borda do painel recolhe e expande a lateral; a escolha fica
+  guardada entre sessões.
 - Diagramas sem layout são posicionados automaticamente; use "Ajustar" para
   enquadrar e o mouse para navegar (arrastar) e dar zoom (roda).
 

--- a/apps/playground/index.html
+++ b/apps/playground/index.html
@@ -23,7 +23,7 @@
         <button id="start" type="button">Iniciar</button>
         <button id="autorun" type="button">Executar tudo</button>
         <button id="reset" type="button" class="secondary">Reiniciar</button>
-        <button id="replay" type="button" class="secondary">Reprisar</button>
+        <button id="replay" type="button" class="secondary">Run</button>
         <button id="metrics" type="button" class="secondary">Métricas</button>
         <button id="fit" type="button" class="secondary">Ajustar</button>
       </div>
@@ -41,11 +41,22 @@
       </div>
     </header>
 
-    <main class="app-main">
+    <main class="app-main" id="app-main">
       <section id="diagram" class="diagram" aria-label="Diagrama BPMN"></section>
       <section id="editor" class="diagram hidden" aria-label="Editor BPMN"></section>
 
-      <aside class="panel">
+      <button
+        id="panel-toggle"
+        class="panel-toggle"
+        type="button"
+        aria-expanded="true"
+        aria-controls="panel"
+        title="Recolher painel"
+      >
+        ›
+      </button>
+
+      <aside class="panel" id="panel">
         <div class="panel-block" data-mode="edit" hidden>
           <h2>Validação</h2>
           <div id="validation" class="validation"></div>
@@ -64,6 +75,11 @@
         <div class="panel-block" data-mode="run">
           <h2>Timers</h2>
           <div id="timers" class="timers"></div>
+        </div>
+
+        <div class="panel-block" data-mode="run">
+          <h2>Variáveis do processo</h2>
+          <div id="variable-hints" class="hints"></div>
         </div>
 
         <div class="panel-block" data-mode="run">

--- a/apps/playground/src/main.ts
+++ b/apps/playground/src/main.ts
@@ -1,5 +1,7 @@
 import {
   parseBpmn,
+  processVariables,
+  suggestVariables,
   WorkflowEngine,
   type BpmnModel,
   type EngineMode,
@@ -7,6 +9,7 @@ import {
   type FlowNode,
   type PendingTask,
   type TokenSnapshot,
+  type VariableUsage,
   type ValidationResult,
 } from '@bpmn-flow/core';
 import { BpmnFlowViewer, ExecutionReplay } from '@bpmn-flow/viewer';
@@ -55,6 +58,9 @@ const els = {
   status: $<HTMLParagraphElement>('status'),
   actions: $<HTMLDivElement>('actions'),
   timers: $<HTMLDivElement>('timers'),
+  variableHints: $<HTMLDivElement>('variable-hints'),
+  panelToggle: $<HTMLButtonElement>('panel-toggle'),
+  appMain: $<HTMLElement>('app-main'),
   variables: $<HTMLTextAreaElement>('variables'),
   variablesView: $<HTMLPreElement>('variables-view'),
   log: $<HTMLOListElement>('log'),
@@ -129,6 +135,7 @@ async function loadDiagram(xml: string): Promise<void> {
   currentXml = xml;
   currentModel = await parseBpmn(xml);
   nodesById = flattenNodes(currentModel);
+  renderVariableHints();
   await viewer.load(xml);
   teardownEngine();
   if (replayTimer !== undefined) {
@@ -253,6 +260,55 @@ function actionButton(text: string, onClick: () => void): void {
   button.textContent = text;
   button.addEventListener('click', onClick);
   els.actions.append(button);
+}
+
+/**
+ * Mostra as variáveis que o diagrama realmente lê — com a expressão que as usa —
+ * e preenche a caixa JSON com um valor que faz cada caminho acontecer.
+ */
+function renderVariableHints(): void {
+  els.variableHints.replaceChildren();
+  const process = currentModel?.processes[0];
+  if (!process) return;
+
+  const usages = processVariables(process);
+  if (usages.length === 0) {
+    const none = document.createElement('p');
+    none.className = 'muted';
+    none.textContent = 'Este processo não lê nenhuma variável.';
+    els.variableHints.append(none);
+  } else {
+    for (const usage of usages) els.variableHints.append(hintCard(usage));
+  }
+
+  // A caixa JSON começa com o que faz o processo andar, em vez de "{}".
+  els.variables.value = JSON.stringify(suggestVariables(process), null, 2);
+}
+
+function hintCard(usage: VariableUsage): HTMLElement {
+  const card = document.createElement('div');
+  card.className = 'hint';
+
+  const name = document.createElement('p');
+  name.className = 'hint-name';
+  name.textContent =
+    usage.suggestion === undefined
+      ? usage.name
+      : `${usage.name} = ${JSON.stringify(usage.suggestion)}`;
+  card.append(name);
+
+  const usedBy = document.createElement('p');
+  usedBy.className = 'hint-usage';
+  if (usage.kind === 'collection') {
+    usedBy.textContent = `coleção da multi-instância em ${usage.usedBy.join(', ')}`;
+  } else {
+    const expression = document.createElement('span');
+    expression.className = 'hint-expression';
+    expression.textContent = usage.expressions[0] ?? '';
+    usedBy.append(expression, ` · ${usage.usedBy.join(', ')}`);
+  }
+  card.append(usedBy);
+  return card;
 }
 
 /** Timers pendentes, com atalho para adiantar o relógio na demonstração. */
@@ -470,6 +526,7 @@ els.reset.addEventListener('click', () => {
 });
 els.fit.addEventListener('click', () => viewer.fit());
 els.replay.addEventListener('click', () => replayRun());
+els.panelToggle.addEventListener('click', () => togglePanel());
 els.metrics.addEventListener('click', () => toggleMetrics());
 
 els.modeRun.addEventListener('click', () => void setMode('run'));
@@ -491,7 +548,24 @@ els.validate.addEventListener('click', () => void validate());
 els.save.addEventListener('click', () => void save());
 els.editFit.addEventListener('click', () => void ensureEditor().then((e) => e.fit()));
 
+const PANEL_KEY = 'bpmn-flow:panel-collapsed';
+
+/** Recolhe ou expande o painel lateral, reenquadrando o diagrama depois. */
+function togglePanel(collapsed = !els.appMain.classList.contains('panel-collapsed')): void {
+  els.appMain.classList.toggle('panel-collapsed', collapsed);
+  els.panelToggle.textContent = collapsed ? '‹' : '›';
+  els.panelToggle.title = collapsed ? 'Expandir painel' : 'Recolher painel';
+  els.panelToggle.setAttribute('aria-expanded', String(!collapsed));
+  localStorage.setItem(PANEL_KEY, String(collapsed));
+  // A área do canvas mudou de tamanho: reenquadra depois da transição.
+  window.setTimeout(() => {
+    if (els.editorEl.classList.contains('hidden')) viewer.fit();
+    else void ensureEditor().then((active) => active.fit());
+  }, 220);
+}
+
 async function init(): Promise<void> {
+  togglePanel(localStorage.getItem(PANEL_KEY) === 'true');
   await populateSamples();
   await loadSelectedSample();
 }

--- a/apps/playground/src/style.css
+++ b/apps/playground/src/style.css
@@ -138,23 +138,67 @@ button.secondary:hover {
 }
 
 .app-main {
+  --panel-width: 360px;
   display: flex;
   flex: 1;
   min-height: 0;
+  /* O SVG do diagrama é maior que o container: sem isto ele passa por cima. */
+  overflow: hidden;
+  position: relative;
+}
+
+.app-main.panel-collapsed {
+  --panel-width: 0px;
 }
 
 .diagram {
   flex: 1;
   min-width: 0;
+  overflow: hidden;
+  position: relative;
   background: var(--surface);
 }
 
 .panel {
-  width: 360px;
+  flex: 0 0 var(--panel-width);
+  width: var(--panel-width);
   border-left: 1px solid var(--border);
   background: var(--surface);
   overflow-y: auto;
   padding: 1rem;
+  /* Acima do diagrama, para nunca ser coberto por ele. */
+  position: relative;
+  z-index: 1;
+  transition:
+    flex-basis 0.18s ease,
+    width 0.18s ease;
+}
+
+.panel-collapsed .panel {
+  padding: 0;
+  border-left: none;
+  overflow: hidden;
+}
+
+.panel-toggle {
+  position: absolute;
+  top: 0.6rem;
+  right: calc(var(--panel-width) + 0.5rem);
+  z-index: 2;
+  width: 1.9rem;
+  height: 1.9rem;
+  padding: 0;
+  line-height: 1;
+  font-size: 1.1rem;
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted);
+  box-shadow: 0 1px 4px rgb(31 41 51 / 18%);
+  transition: right 0.18s ease;
+}
+
+.panel-toggle:hover {
+  color: var(--text);
 }
 
 .panel-block + .panel-block {
@@ -271,4 +315,36 @@ button.secondary:hover {
 .timers .timer {
   margin: 0 0 0.35rem;
   font-size: 0.85rem;
+}
+
+/* --- Variáveis descobertas no diagrama ---------------------------------- */
+
+.hints {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.hint {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.45rem 0.6rem;
+  background: var(--surface);
+}
+
+.hint-name {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.hint-usage {
+  margin: 0.2rem 0 0;
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+.hint-expression {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }

--- a/docs/BPMN-STANDARD.md
+++ b/docs/BPMN-STANDARD.md
@@ -26,10 +26,11 @@ Um escopo termina quando não sobra nenhum token nele.
 | `endEvent` (escalation)           | Propaga a escalation para fora; sem tratador, a execução segue normalmente.                         |
 | `endEvent` (cancel)               | Dentro de uma `transaction`: compensa o que foi feito e sai pelo evento de borda de cancelamento.   |
 | `endEvent` (compensation)         | Dispara os tratadores de compensação do escopo, em ordem inversa.                                   |
-| `intermediateThrowEvent`          | Pass-through: conclui e segue adiante.                                                              |
+| `intermediateThrowEvent`          | Lança o gatilho (sinal, mensagem, escalation, compensação) e segue adiante.                         |
 | `intermediateCatchEvent`          | Estaciona o token (`waitReason: "catchEvent"`) até `signal()` ou até o timer vencer.                |
 | `boundaryEvent` interrompente     | Descarta o token da atividade hospedeira (ou o escopo do subprocesso) e segue pelo fluxo do evento. |
 | `boundaryEvent` não interrompente | Mantém a atividade em execução e cria um token adicional no fluxo do evento.                        |
+| `boundaryEvent` condicional       | Reavaliado a cada quiescência do motor; dispara uma vez por ativação da atividade.                  |
 
 Definições de evento reconhecidas pelo parser: `message`, `timer`, `error`,
 `signal`, `escalation`, `conditional`, `compensation`, `cancel`, `terminate` e
@@ -55,6 +56,13 @@ token que a disparou seguir adiante.
 `transaction` + `cancelEventDefinition` combinam as duas coisas: cancelar
 compensa o que já foi feito, descarta o resto do trabalho da transação e sai
 pelo evento de borda de cancelamento.
+
+### Eventos de lançamento
+
+Um evento de lançamento com definição de **sinal** ou **mensagem** entrega o
+gatilho na hora, para todos os assinantes correspondentes do próprio processo —
+eventos de captura parados, eventos de borda e event subprocesses. É como um
+`signal()` externo, disparado de dentro do diagrama.
 
 ### Escalation
 
@@ -91,6 +99,35 @@ a execução.
   repetido (`options.retry`) e, com `onHandlerError: "incident"`, vira um
   incidente que segura o token em vez de derrubar a execução.
 
+## Subprocesso ad-hoc
+
+`adHocSubProcess` não tem fluxo de sequência ligando suas atividades: toda
+atividade sem fluxo de entrada é elegível. `ordering="Parallel"` (padrão) inicia
+todas de uma vez; `Sequential` executa uma de cada vez, na ordem do documento.
+Um `completionCondition` verdadeiro encerra o escopo antes de todas rodarem,
+descartando o que sobrou.
+
+## Dados de entrada e saída
+
+`dataInputAssociation` e `dataOutputAssociation` na forma `assignment/from/to`
+copiam valores para dentro e para fora de um subprocesso ou call activity:
+
+```xml
+<bpmn:callActivity id="Chamar" calledElement="Cobranca">
+  <bpmn:dataInputAssociation>
+    <bpmn:assignment><bpmn:from>valorPedido</bpmn:from><bpmn:to>valor</bpmn:to></bpmn:assignment>
+  </bpmn:dataInputAssociation>
+  <bpmn:dataOutputAssociation>
+    <bpmn:assignment><bpmn:from>recibo</bpmn:from><bpmn:to>reciboDaCobranca</bpmn:to></bpmn:assignment>
+  </bpmn:dataOutputAssociation>
+</bpmn:callActivity>
+```
+
+Declarar um mapeamento de entrada **isola** o escopo: o processo chamado passa a
+enxergar apenas o que foi mapeado, e o que ele escreve fica nele — só o
+mapeamento de saída atravessa de volta. Sem mapeamento nenhum, o escopo filho
+continua lendo as variáveis do pai pela cadeia de escopos.
+
 ## Repetição de atividades
 
 ### Multi-instância
@@ -125,6 +162,10 @@ para no evento — ou em que a atividade com evento de borda começa a esperar.
 
 Um timer de borda é desarmado quando a atividade termina antes do prazo, e o
 vencimento faz parte do estado serializado, então sobrevive a um restart.
+
+Um ciclo (`R3/PT1H`, `R/PT1H`) em evento de borda **não interrompente** rearma a
+cada disparo — três lembretes de hora em hora, ou lembretes enquanto a atividade
+durar. As repetições restantes também fazem parte do estado.
 
 ## Raias e atribuição
 
@@ -199,24 +240,22 @@ expressão que ainda assim lança, ou que não retorna `true`, é tratada como f
 
 ## Divergências assumidas
 
-1. **Ciclos de timer disparam uma vez.** `timeCycle` (`R3/PT10M`) é lido como o
-   intervalo, sem repetir. O motor também não tem relógio próprio: calcula o
-   vencimento e o host chama `tick()` — o `@bpmn-flow/server` faz isso em
-   intervalo configurável.
+1. **O motor não tem relógio próprio.** Ele calcula o vencimento e o host chama
+   `tick()` — o `@bpmn-flow/server` faz isso em intervalo configurável. Um ciclo
+   (`R3/PT10M`) repete só em evento de borda não interrompente, que é onde
+   repetir faz sentido.
 2. **Gateway complexo sem `activationCondition`** cai no comportamento
    inclusivo, em vez de recusar o diagrama.
 3. **Modo `auto`.** Fora da especificação, existe para simular execuções:
    resolve automaticamente qualquer espera e, quando um gateway não tem default
    nem condição verdadeira, toma o primeiro fluxo de saída. O modo `automation`
    (padrão) segue a especificação.
-4. **Evento de borda condicional não é reavaliado sozinho.** O de captura é
-   (a cada quiescência do motor); o de borda depende de `signal()` pelo id.
-5. **Mapeamento de dados não é executado.** `ioSpecification` e data
-   associations de entrada/saída são ignorados: o escopo filho lê as variáveis
-   do pai pela cadeia de escopos.
-6. **Correlação de mensagem por chave não existe.** A entrega é por nome da
+4. **Mapeamento de dados por `assignment`.** As data associations são lidas na
+   forma `assignment/from/to` (expressões); `ioSpecification` com data inputs e
+   outputs formais não é interpretado.
+5. **Correlação de mensagem por chave não existe.** A entrega é por nome da
    mensagem/sinal ou pelo id do elemento.
-7. **DMN está fora de escopo.** `businessRuleTask` executa o handler que você
+6. **DMN está fora de escopo.** `businessRuleTask` executa o handler que você
    registrar, e é por ali que um motor de decisão entra.
 
 ## Medição

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -22,6 +22,18 @@ fluxos de sequência com condições e colaboração. A interchange de diagrama 
 
 Lança `BpmnParseError` para XML inválido ou sem processo.
 
+### `processVariables(process)` e `suggestVariables(process)`
+
+Descobrem, a partir das expressões do diagrama, quais variáveis o processo lê —
+condições de fluxo, cardinalidade e coleção de multi-instância, condição de
+conclusão, condição de ativação, eventos condicionais — com a expressão que as
+usa e um valor sugerido pela forma dela. Variáveis que o processo só escreve
+(item da multi-instância, coleção de saída) ficam de fora.
+
+```ts
+suggestVariables(process); // { pago: true, valor: 1001, itens: ['item-1', 'item-2'] }
+```
+
 ### `addFlowReferences(xml): Promise<string>`
 
 Devolve o mesmo XML com o `<bpmn:incoming>`/`<bpmn:outgoing>` de cada nó

--- a/packages/core/src/engine/engine.ts
+++ b/packages/core/src/engine/engine.ts
@@ -20,7 +20,7 @@ import {
   type TokenState,
   type TimerState,
 } from './state.js';
-import { resolveTimerDueAt } from './timers.js';
+import { parseTimerCycle, resolveTimerDueAt } from './timers.js';
 import type {
   ActivityMetrics,
   EngineEvents,
@@ -48,6 +48,12 @@ interface Scope {
   variables: Record<string, unknown>;
   /** Set on scopes created for one instance of a loop/multi-instance activity. */
   loopId?: string;
+  /** Data-mapped scopes do not read the caller's variables. */
+  isolated?: boolean;
+  /** Ad-hoc subprocess: activities not started yet. */
+  adHocPending?: string[];
+  /** Ad-hoc subprocess: expression that ends it early. */
+  completionCondition?: string;
   tokens: Set<RuntimeToken>;
 }
 
@@ -111,6 +117,8 @@ export class WorkflowEngine {
   private readonly compensations: { activityId: string; scopeId: string }[] = [];
   /** Activities whose handler failed, keyed by token id. */
   private readonly incidents = new Map<string, IncidentState>();
+  /** `boundaryId:hostTokenId` of conditional boundaries already fired. */
+  private readonly firedConditionals = new Set<string>();
   /** Pending timers keyed by `tokenId:nodeId`. */
   private readonly timers = new Map<string, TimerState>();
   private readonly armedEvents = new Map<string, string>();
@@ -451,6 +459,8 @@ export class WorkflowEngine {
         ...(scope.hostNodeId ? { hostNodeId: scope.hostNodeId } : {}),
         ...(scope.parentToken ? { parentTokenId: scope.parentToken.id } : {}),
         ...(scope.loopId ? { loopId: scope.loopId } : {}),
+        ...(scope.isolated ? { isolated: true } : {}),
+        ...(scope.adHocPending ? { adHocPending: [...scope.adHocPending] } : {}),
         variables: { ...scope.variables },
       })),
       tokens: [...tokens.values()],
@@ -554,10 +564,17 @@ export class WorkflowEngine {
         tokens: new Set(),
         variables: { ...stored.variables },
         ...(stored.parentScopeId ? { parentScopeId: stored.parentScopeId } : {}),
-        ...(parentScope ? { parentScope } : {}),
+        // An isolated scope keeps its own data: no variable chain to the caller.
+        ...(parentScope && !stored.isolated ? { parentScope } : {}),
         ...(stored.hostNodeId ? { hostNodeId: stored.hostNodeId } : {}),
         ...(stored.loopId ? { loopId: stored.loopId } : {}),
+        ...(stored.isolated ? { isolated: true } : {}),
+        ...(stored.adHocPending ? { adHocPending: [...stored.adHocPending] } : {}),
       };
+      // The completion condition lives on the host node, so it is re-derived.
+      const host =
+        parentScope && stored.hostNodeId ? parentScope.graph.node(stored.hostNodeId) : undefined;
+      if (host?.completionCondition) scope.completionCondition = host.completionCondition;
       scopesById.set(scope.id, scope);
       this.scopes.push(scope);
     }
@@ -703,6 +720,9 @@ export class WorkflowEngine {
     token.scope.tokens.delete(token);
     this.waiting.delete(token.id);
     this.clearTimersFor(token.id);
+    for (const key of [...this.firedConditionals]) {
+      if (key.endsWith(`:${token.id}`)) this.firedConditionals.delete(key);
+    }
     // A discarded token must never be processed again, even if it was already
     // queued — cancellation (terminate, interrupting boundary) relies on this.
     const queued = this.ready.indexOf(token);
@@ -770,6 +790,7 @@ export class WorkflowEngine {
     if (!definition) return;
     const dueAt = resolveTimerDueAt(definition, this.now());
     if (dueAt === undefined) return;
+    const cycle = parseTimerCycle(definition);
     this.timers.set(timerKey(token.id, node.id), {
       tokenId: token.id,
       nodeId: node.id,
@@ -777,6 +798,23 @@ export class WorkflowEngine {
       kind,
       dueAt,
       definition,
+      // A cycle keeps firing while the activity it guards is still running.
+      ...(cycle ? { repetitions: cycle.repetitions } : {}),
+    });
+  }
+
+  /** Schedules the next firing of a repeating boundary timer, if any is left. */
+  private rearmCycle(entry: TimerState, node: FlowNode): void {
+    const cycle = parseTimerCycle(entry.definition);
+    if (!cycle) return;
+    const remaining = entry.repetitions === null ? null : (entry.repetitions ?? 1) - 1;
+    if (remaining !== null && remaining <= 0) return;
+    const dueAt = resolveTimerDueAt(cycle.interval, this.now());
+    if (dueAt === undefined) return;
+    this.timers.set(timerKey(entry.tokenId, node.id), {
+      ...entry,
+      dueAt,
+      ...(remaining === null ? { repetitions: null } : { repetitions: remaining }),
     });
   }
 
@@ -794,7 +832,10 @@ export class WorkflowEngine {
       const scope = this.scopes.find((s) => s.id === entry.scopeId);
       const boundary = scope?.graph.node(entry.nodeId);
       if (!scope || !boundary) return false;
-      return this.fireBoundary(scope, boundary);
+      const fired = this.fireBoundary(scope, boundary);
+      // A cyclic, non-interrupting boundary rearms for its next firing.
+      if (fired && boundary.cancelActivity === false) this.rearmCycle(entry, boundary);
+      return fired;
     }
 
     const token = this.waiting.get(entry.tokenId);
@@ -825,14 +866,19 @@ export class WorkflowEngine {
    * `setLocal` in a handler to keep a value inside the current scope.
    */
   private writeVariable(scope: Scope | undefined, name: string, value: unknown): void {
+    let outermost: Scope | undefined;
     for (let current = scope; current; current = current.parentScope) {
       if (Object.hasOwn(current.variables, name)) {
         current.variables[name] = value;
         return;
       }
+      outermost = current;
     }
-    const root = this.scopes[0];
-    if (root) root.variables[name] = value;
+    // A new variable lands on the outermost scope the activity can see. For an
+    // isolated scope (data-mapped call activity) that is the scope itself, so
+    // its data never leaks into the caller.
+    const target = outermost ?? this.scopes[0];
+    if (target) target.variables[name] = value;
     else this.initialVariables[name] = value;
   }
 
@@ -908,6 +954,8 @@ export class WorkflowEngine {
       if (this.fireReadyInclusiveJoins()) continue;
       // A conditional event fires as soon as its condition holds.
       if (this.fireReadyConditionalEvents()) continue;
+      // An ad-hoc subprocess may declare itself done before running everything.
+      if (this.finishSatisfiedAdHocScopes()) continue;
       // Auto mode resolves the next wait to keep the simulation moving.
       if (this.mode === 'auto' && this.autoResolveWait()) continue;
       break;
@@ -946,6 +994,7 @@ export class WorkflowEngine {
         const escalation = detailOfKind(node, 'escalation');
         // An escalation is a shout for help: the branch carries on either way.
         if (escalation) this.raiseEscalation(token.scope, escalation.code ?? escalation.reference);
+        this.throwTrigger(node);
         this.completeNode(token);
         this.leaveViaOutgoing(token);
         return;
@@ -1006,6 +1055,8 @@ export class WorkflowEngine {
       this.checkScopeCompletion(token.scope);
       return;
     }
+    // An end event may also throw a signal or a message on its way out.
+    this.throwTrigger(node);
     if (kind === 'error') {
       this.discard(token);
       const code = node.event?.code ?? node.event?.reference;
@@ -1131,6 +1182,13 @@ export class WorkflowEngine {
     this.armBoundaryTimers(token);
     const childGraph = new ProcessGraph(called);
     const child = this.createScope(childGraph, token, node.id);
+    this.applyDataInput(node, token.scope, child);
+
+    if (node.kind === 'adHocSubProcess') {
+      this.startAdHoc(child, node, childGraph);
+      return;
+    }
+
     const starts = childGraph.startNodes().filter((s) => !s.event || s.event.kind === 'none');
     if (starts.length === 0) {
       // No plain start: complete immediately.
@@ -1140,9 +1198,57 @@ export class WorkflowEngine {
     for (const start of starts) this.spawn(child, start.id);
   }
 
+  /**
+   * Ad-hoc subprocess: its activities have no sequence flow telling them when
+   * to run. Every activity without an incoming flow is eligible; `ordering`
+   * decides whether they run together or one at a time, and a
+   * `completionCondition` can end the scope before all of them ran.
+   */
+  private startAdHoc(scope: Scope, node: FlowNode, graph: ProcessGraph): void {
+    const activities = graph
+      .allNodes()
+      .filter((candidate) => isActivityKind(candidate.kind) && candidate.incoming.length === 0);
+    if (activities.length === 0) {
+      this.finishSubProcess(scope);
+      return;
+    }
+    if (node.completionCondition) scope.completionCondition = node.completionCondition;
+
+    if (node.sequential) {
+      scope.adHocPending = activities.slice(1).map((activity) => activity.id);
+      this.spawn(scope, activities[0]!.id);
+      return;
+    }
+    scope.adHocPending = [];
+    for (const activity of activities) this.spawn(scope, activity.id);
+  }
+
+  /** Copies the caller's values into the activity's scope, isolating it. */
+  private applyDataInput(node: FlowNode, from: Scope, into: Scope): void {
+    if (!node.dataInput || node.dataInput.length === 0) return;
+    const source = this.mergedVariables(from);
+    for (const mapping of node.dataInput) {
+      into.variables[mapping.to] = evaluateExpression(mapping.from, source);
+    }
+    // Declaring a mapping means the activity works with its own data only.
+    delete into.parentScope;
+    into.isolated = true;
+  }
+
+  /** Copies the activity's results back to the caller. */
+  private applyDataOutput(node: FlowNode, from: Scope, into: Scope): void {
+    if (!node.dataOutput || node.dataOutput.length === 0) return;
+    const source = this.mergedVariables(from);
+    for (const mapping of node.dataOutput) {
+      this.writeVariable(into, mapping.to, evaluateExpression(mapping.from, source));
+    }
+  }
+
   private finishSubProcess(child: Scope): void {
     const parent = child.parentToken;
     const hostId = child.hostNodeId;
+    const host = hostId ? parent?.scope.graph.node(hostId) : undefined;
+    if (host && parent) this.applyDataOutput(host, child, parent.scope);
     this.scopes.splice(this.scopes.indexOf(child), 1);
     if (!parent || !hostId) return;
     parent.scope.tokens.add(parent);
@@ -1707,6 +1813,19 @@ export class WorkflowEngine {
   }
 
   /**
+   * A throw event with a signal or message definition delivers it, so catch
+   * events, boundary events and event subprocesses listening for that name
+   * react — the same broadcast an external `signal()` performs.
+   */
+  private throwTrigger(node: FlowNode): void {
+    for (const detail of detailsOf(node)) {
+      if (detail.kind !== 'signal' && detail.kind !== 'message') continue;
+      const name = detail.reference ?? node.messageRef;
+      if (name) this.deliverSignal(name);
+    }
+  }
+
+  /**
    * Escalation travels outwards: it looks for an escalation boundary event on
    * the activity that hosts this scope, then for an escalation event
    * subprocess. Unlike an error, an unhandled escalation is not a failure.
@@ -1856,6 +1975,40 @@ export class WorkflowEngine {
       this.leaveViaOutgoing(token);
       return true;
     }
+    return this.fireReadyConditionalBoundaries();
+  }
+
+  /**
+   * A conditional boundary event watches the variables while its activity runs.
+   * Each activation fires once, so a non-interrupting one does not loop.
+   */
+  private fireReadyConditionalBoundaries(): boolean {
+    for (const token of [...this.waiting.values()]) {
+      const scope = token.scope;
+      for (const boundary of scope.graph.boundaryEvents(token.nodeId)) {
+        const condition = detailOfKind(boundary, 'conditional')?.condition;
+        if (!condition) continue;
+        const key = `${boundary.id}:${token.id}`;
+        if (this.firedConditionals.has(key)) continue;
+        if (!evaluateCondition(condition, this.mergedVariables(scope))) continue;
+        this.firedConditionals.add(key);
+        if (this.fireBoundary(scope, boundary)) return true;
+      }
+    }
+    return false;
+  }
+
+  /** Ends ad-hoc scopes whose completion condition already holds. */
+  private finishSatisfiedAdHocScopes(): boolean {
+    for (const scope of [...this.scopes]) {
+      if (!scope.completionCondition) continue;
+      if (!evaluateCondition(scope.completionCondition, this.mergedVariables(scope))) continue;
+      for (const token of [...scope.tokens]) this.discard(token);
+      scope.adHocPending = [];
+      delete scope.completionCondition;
+      this.finishSubProcess(scope);
+      return true;
+    }
     return false;
   }
 
@@ -1918,6 +2071,12 @@ export class WorkflowEngine {
   private checkScopeCompletion(scope: Scope): void {
     if (scope.tokens.size > 0) return;
     if (this.hasPendingFor(scope)) return;
+    // Ad-hoc, one at a time: the next activity only starts now.
+    const next = scope.adHocPending?.shift();
+    if (next !== undefined) {
+      this.spawn(scope, next);
+      return;
+    }
     if (scope.parentToken) {
       this.finishSubProcess(scope);
       return;

--- a/packages/core/src/engine/state.ts
+++ b/packages/core/src/engine/state.ts
@@ -14,7 +14,7 @@ import type { EngineMode, ExecutionStatus, HistoryEntry, WaitReason } from './ty
  *
  * Bump {@link ENGINE_STATE_VERSION} whenever the shape changes.
  */
-export const ENGINE_STATE_VERSION = 5;
+export const ENGINE_STATE_VERSION = 6;
 
 /** Where a token currently sits, since not every token lives in a scope. */
 export type TokenPlacement =
@@ -48,6 +48,10 @@ export interface ScopeState {
   variables?: Record<string, unknown>;
   /** Set when the scope holds one instance of a repeated activity. */
   loopId?: string;
+  /** Data-mapped scopes do not read the caller's variables. */
+  isolated?: boolean;
+  /** Ad-hoc subprocess: activities not started yet. */
+  adHocPending?: string[];
 }
 
 /** A multi-instance or standard loop in progress. */
@@ -94,6 +98,8 @@ export interface TimerState {
   dueAt: number;
   /** The original definition (`PT5M`, a date, or a cycle). */
   definition: string;
+  /** Cycles only: firings left, or `null` while the activity lasts. */
+  repetitions?: number | null;
 }
 
 /** Arrival counts per incoming flow of a parallel join. */

--- a/packages/core/src/engine/timers.ts
+++ b/packages/core/src/engine/timers.ts
@@ -42,11 +42,34 @@ export function parseIsoDuration(text: string): number | undefined {
 }
 
 /**
+ * A repeating timer: `R3/PT10M` runs three times every ten minutes, `R/PT10M`
+ * runs until the activity it guards ends.
+ */
+export interface TimerCycle {
+  /** How many times it still fires; `null` means "as long as it applies". */
+  repetitions: number | null;
+  /** The interval between firings. */
+  interval: string;
+}
+
+/**
+ * Reads a cycle definition (`R3/PT10M`, `R/PT1H`). Returns `undefined` for
+ * anything that is not a cycle.
+ */
+export function parseTimerCycle(definition: string): TimerCycle | undefined {
+  const match = /^R(\d*)\/(.+)$/.exec(definition.trim());
+  if (!match) return undefined;
+  const repetitions = match[1] ? Number(match[1]) : null;
+  return { repetitions, interval: match[2]!.trim() };
+}
+
+/**
  * Resolves a timer definition to an absolute due date in epoch milliseconds.
  *
  * - duration (`PT5M`) — relative to `now`
  * - date (`2026-08-20T10:00:00Z`) — used as is
- * - cycle (`R3/PT10M`) — only the interval is honoured; the engine fires once
+ * - cycle (`R3/PT10M`) — the first firing; {@link parseTimerCycle} carries the
+ *   repetitions, which a non-interrupting boundary event honours
  *
  * Returns `undefined` when the definition cannot be understood, so the caller
  * can fall back to waiting for an explicit signal.
@@ -55,10 +78,8 @@ export function resolveTimerDueAt(definition: string, now: number): number | und
   const text = definition.trim();
   if (!text) return undefined;
 
-  if (text.startsWith('R')) {
-    const interval = text.slice(text.indexOf('/') + 1);
-    return interval === text ? undefined : resolveTimerDueAt(interval, now);
-  }
+  const cycle = parseTimerCycle(text);
+  if (cycle) return resolveTimerDueAt(cycle.interval, now);
   if (text.startsWith('P')) {
     const duration = parseIsoDuration(text);
     return duration === undefined ? undefined : now + duration;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,13 +1,16 @@
 export * from './model/kinds.js';
 export * from './model/types.js';
 export { ProcessGraph } from './model/graph.js';
+export { processVariables, suggestVariables } from './model/variables.js';
+export type { VariableUsage } from './model/variables.js';
 export { parseBpmn } from './parser/parse.js';
 export { addFlowReferences } from './parser/references.js';
 export { validateBpmn, validateModel } from './validate.js';
 export type { ValidationIssue, ValidationResult } from './validate.js';
 export { WorkflowEngine } from './engine/engine.js';
 export { ENGINE_STATE_VERSION } from './engine/state.js';
-export { parseIsoDuration, resolveTimerDueAt } from './engine/timers.js';
+export { parseIsoDuration, parseTimerCycle, resolveTimerDueAt } from './engine/timers.js';
+export type { TimerCycle } from './engine/timers.js';
 export type {
   CompensationState,
   EngineState,

--- a/packages/core/src/model/types.ts
+++ b/packages/core/src/model/types.ts
@@ -102,6 +102,19 @@ export interface FlowNode {
   /** Receive/send tasks: name of the message they wait for or emit. */
   messageRef?: string;
 
+  /** Ad-hoc subprocess: expression that ends it before every activity ran. */
+  completionCondition?: string;
+  /** Ad-hoc subprocess: whether its activities run one at a time. */
+  sequential?: boolean;
+
+  /**
+   * Values copied into the activity's scope when it starts. Declaring any of
+   * them isolates the scope: it stops seeing the caller's variables.
+   */
+  dataInput?: DataMapping[];
+  /** Values copied back to the caller when the activity completes. */
+  dataOutput?: DataMapping[];
+
   /** Sub-processes: id of a called global process (call activity). */
   calledElement?: string;
   /** Event sub-processes are triggered by their start event, not by a token. */
@@ -135,6 +148,15 @@ export interface Association {
   id: string;
   sourceRef: string;
   targetRef: string;
+}
+
+/**
+ * One assignment of a data association: read `from` in the source scope, write
+ * the result to `to` in the target scope.
+ */
+export interface DataMapping {
+  from: string;
+  to: string;
 }
 
 /** A participant (pool) in a collaboration. */

--- a/packages/core/src/model/variables.ts
+++ b/packages/core/src/model/variables.ts
@@ -1,0 +1,214 @@
+import type { ProcessModel } from './types.js';
+
+/**
+ * Which variables a process actually reads, discovered from the expressions in
+ * the diagram itself: sequence-flow conditions, loop cardinalities and
+ * collections, completion and activation conditions, conditional events.
+ *
+ * A UI can use this to tell the operator what the process expects — "this
+ * gateway only opens when `pago` is true" — instead of leaving them guessing in
+ * front of an empty JSON box.
+ */
+
+/** Where a variable shows up, and a value that would exercise that path. */
+export interface VariableUsage {
+  name: string;
+  /** How the variable is consumed. */
+  kind: 'condition' | 'collection';
+  /** Expressions mentioning it, in document order. */
+  expressions: string[];
+  /** Elements whose expression mentions it (name when there is one). */
+  usedBy: string[];
+  /**
+   * A value that satisfies the first expression, when one can be inferred from
+   * its shape (`pago === true` suggests `true`, `valor > 1000` suggests 1001).
+   */
+  suggestion?: unknown;
+}
+
+/** Names the engine provides on its own; never asked from the caller. */
+const ENGINE_PROVIDED = new Set(['loopCounter', 'arrived']);
+
+/** Globals an expression may legitimately reference. */
+const GLOBALS = new Set([
+  'true',
+  'false',
+  'null',
+  'undefined',
+  'NaN',
+  'Infinity',
+  'typeof',
+  'new',
+  'in',
+  'of',
+  'void',
+  'Math',
+  'Date',
+  'JSON',
+  'Number',
+  'String',
+  'Boolean',
+  'Array',
+  'Object',
+  'RegExp',
+  'parseInt',
+  'parseFloat',
+  'isNaN',
+  'isFinite',
+]);
+
+interface Mention {
+  expression: string;
+  owner: string;
+  kind: VariableUsage['kind'];
+}
+
+/**
+ * Every variable the process reads, in the order they appear.
+ *
+ * Variables the process only writes (a multi-instance item, an output
+ * collection) are left out: the caller does not need to provide them.
+ */
+export function processVariables(process: ProcessModel): VariableUsage[] {
+  const mentions = new Map<string, Mention[]>();
+  const produced = new Set<string>(ENGINE_PROVIDED);
+
+  const remember = (name: string, mention: Mention): void => {
+    const current = mentions.get(name) ?? [];
+    current.push(mention);
+    mentions.set(name, current);
+  };
+
+  const readExpression = (expression: string | undefined, owner: string): void => {
+    if (!expression) return;
+    for (const name of identifiersOf(expression)) {
+      remember(name, { expression, owner, kind: 'condition' });
+    }
+  };
+
+  const walk = (scope: ProcessModel): void => {
+    for (const flow of scope.sequenceFlows) {
+      readExpression(flow.conditionExpression, flow.name ?? flow.id);
+    }
+    for (const node of scope.flowNodes) {
+      const owner = node.name ?? node.id;
+      readExpression(node.activationCondition, owner);
+      for (const detail of node.events ?? (node.event ? [node.event] : [])) {
+        readExpression(detail.condition, owner);
+      }
+      if (node.loop) {
+        readExpression(node.loop.cardinality, owner);
+        readExpression(node.loop.completionCondition, owner);
+        readExpression(node.loop.loopCondition, owner);
+        if (node.loop.collection) {
+          remember(node.loop.collection, {
+            expression: node.loop.collection,
+            owner,
+            kind: 'collection',
+          });
+        }
+        // Written by the engine or by the handler, never asked for.
+        if (node.loop.elementVariable) produced.add(node.loop.elementVariable);
+        if (node.loop.outputElement) produced.add(node.loop.outputElement);
+        if (node.loop.outputCollection) produced.add(node.loop.outputCollection);
+      }
+      if (node.process) walk(node.process);
+    }
+  };
+  walk(process);
+
+  const usages: VariableUsage[] = [];
+  for (const [name, list] of mentions) {
+    if (produced.has(name)) continue;
+    const kind = list.some((mention) => mention.kind === 'collection') ? 'collection' : 'condition';
+    const usage: VariableUsage = {
+      name,
+      kind,
+      expressions: [...new Set(list.map((mention) => mention.expression))],
+      usedBy: [...new Set(list.map((mention) => mention.owner))],
+    };
+    const suggestion = suggestFor(name, kind, usage.expressions);
+    if (suggestion !== undefined) usage.suggestion = suggestion;
+    usages.push(usage);
+  }
+  return usages;
+}
+
+/**
+ * Ready-to-use starting variables: the suggestion of every variable the process
+ * reads. Feed it to `new WorkflowEngine(process, { variables })`, or into the
+ * JSON box of a UI so the operator starts from something that runs.
+ */
+export function suggestVariables(process: ProcessModel): Record<string, unknown> {
+  const variables: Record<string, unknown> = {};
+  for (const usage of processVariables(process)) {
+    if (usage.suggestion !== undefined) variables[usage.name] = usage.suggestion;
+  }
+  return variables;
+}
+
+/** Identifiers an expression reads, ignoring strings, properties and globals. */
+function identifiersOf(expression: string): string[] {
+  const withoutStrings = expression.replace(/'[^']*'|"[^"]*"|`[^`]*`/g, ' ');
+  const names: string[] = [];
+  const pattern = /(^|[^\w$.])([A-Za-z_$][\w$]*)/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(withoutStrings)) !== null) {
+    const name = match[2]!;
+    if (GLOBALS.has(name) || names.includes(name)) continue;
+    names.push(name);
+  }
+  return names;
+}
+
+/** Infers a value that satisfies the expression, from its shape. */
+function suggestFor(
+  name: string,
+  kind: VariableUsage['kind'],
+  expressions: string[],
+): unknown | undefined {
+  if (kind === 'collection') return ['item-1', 'item-2'];
+
+  for (const expression of expressions) {
+    const escaped = name.replace(/[$]/g, '\\$&');
+    const boolean = new RegExp(`\\b${escaped}\\s*(===?|!==?)\\s*(true|false)`).exec(expression);
+    if (boolean) {
+      const wanted = boolean[2] === 'true';
+      return boolean[1]!.startsWith('!') ? !wanted : wanted;
+    }
+
+    const numeric = new RegExp(
+      `\\b${escaped}\\s*(>=|<=|>|<|===?|!==?)\\s*(-?\\d+(?:\\.\\d+)?)`,
+    ).exec(expression);
+    if (numeric) {
+      const value = Number(numeric[2]);
+      switch (numeric[1]) {
+        case '>':
+          return value + 1;
+        case '>=':
+        case '==':
+        case '===':
+          return value;
+        case '<':
+          return value - 1;
+        case '<=':
+          return value;
+        default:
+          return value + 1;
+      }
+    }
+
+    const text = new RegExp(`\\b${escaped}\\s*===?\\s*['"\`]([^'"\`]*)['"\`]`).exec(expression);
+    if (text) return text[1];
+
+    const length = new RegExp(`\\b${escaped}\\.length\\s*(>=|>)\\s*(\\d+)`).exec(expression);
+    if (length) {
+      const size = Number(length[2]) + (length[1] === '>' ? 1 : 0);
+      return Array.from({ length: size }, (_, index) => `item-${index + 1}`);
+    }
+
+    // Bare truthiness check: `${aprovado}` or `aprovado && valor > 10`.
+    if (new RegExp(`(^|[^\\w$.])${escaped}\\s*(&&|\\|\\||\\)|$)`).test(expression)) return true;
+  }
+  return undefined;
+}

--- a/packages/core/src/parser/moddle-types.ts
+++ b/packages/core/src/parser/moddle-types.ts
@@ -51,6 +51,12 @@ export interface MdResourceRole {
   resourceAssignmentExpression?: { expression?: { body?: string } };
 }
 
+/** `bpmn:DataInputAssociation` / `bpmn:DataOutputAssociation`. */
+export interface MdDataAssociation {
+  $type: string;
+  assignment?: { from?: { body?: string }; to?: { body?: string } }[];
+}
+
 /** `bpmn:Lane` with the flow nodes it contains (references resolved). */
 export interface MdLane {
   $type: string;
@@ -101,6 +107,15 @@ export interface MdElement {
   resources?: MdResourceRole[];
   /** Receive/send tasks: the message they wait for or emit. */
   messageRef?: MdRef & { name?: string };
+
+  /** Ad-hoc subprocess: when its activities are considered done. */
+  completionCondition?: { body?: string };
+  /** Ad-hoc subprocess: `Parallel` (default) or `Sequential`. */
+  ordering?: string;
+
+  /** Data mapping in and out of an activity. */
+  dataInputAssociations?: MdDataAssociation[];
+  dataOutputAssociations?: MdDataAssociation[];
 
   // process: swimlanes
   laneSets?: { lanes?: MdLane[] }[];

--- a/packages/core/src/parser/parse.ts
+++ b/packages/core/src/parser/parse.ts
@@ -11,6 +11,7 @@ import {
 import type {
   Association,
   BpmnModel,
+  DataMapping,
   EventDetail,
   FlowNode,
   LoopCharacteristics,
@@ -20,6 +21,7 @@ import type {
   SequenceFlow,
 } from '../model/types.js';
 import type {
+  MdDataAssociation,
   MdElement,
   MdEventDefinition,
   MdLane,
@@ -147,6 +149,19 @@ function readLaneAssignments(lanes: MdLane[] | undefined, into: Map<string, stri
   }
 }
 
+/** Assignments of a data association, as `from`/`to` expression pairs. */
+function readDataMappings(associations: MdDataAssociation[] | undefined): DataMapping[] {
+  const mappings: DataMapping[] = [];
+  for (const association of associations ?? []) {
+    for (const assignment of association.assignment ?? []) {
+      const from = assignment.from?.body;
+      const to = assignment.to?.body;
+      if (from && to) mappings.push({ from, to });
+    }
+  }
+  return mappings;
+}
+
 /** `bpmn:Association` artifacts, which wire compensation handlers. */
 function readAssociations(artifacts: MdElement[] | undefined): Association[] {
   const associations: Association[] = [];
@@ -197,6 +212,14 @@ function readScope(elements: MdElement[]): ScopeAccumulator {
     if (candidates.length > 0) node.candidates = candidates;
     const message = el.messageRef?.name ?? el.messageRef?.id;
     if (message) node.messageRef = message;
+    if (kind === 'adHocSubProcess') {
+      if (el.completionCondition?.body) node.completionCondition = el.completionCondition.body;
+      if (el.ordering?.toLowerCase() === 'sequential') node.sequential = true;
+    }
+    const dataInput = readDataMappings(el.dataInputAssociations);
+    if (dataInput.length > 0) node.dataInput = dataInput;
+    const dataOutput = readDataMappings(el.dataOutputAssociations);
+    if (dataOutput.length > 0) node.dataOutput = dataOutput;
     if (el.triggeredByEvent) node.triggeredByEvent = true;
     if (kind === 'startEvent' && el.isInterrupting !== undefined) {
       node.interrupting = el.isInterrupting;

--- a/packages/core/test/advanced.test.ts
+++ b/packages/core/test/advanced.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from 'vitest';
+import { parseBpmn, parseTimerCycle, WorkflowEngine } from '../src/index.js';
+import type { BpmnModel, ProcessModel } from '../src/index.js';
+import {
+  AD_HOC,
+  AD_HOC_SEQUENTIAL,
+  CONDITIONAL_BOUNDARY,
+  DATA_MAPPING,
+  THROW_SIGNAL,
+  TIMER_CYCLE,
+} from './fixtures.js';
+
+const T0 = Date.parse('2026-08-19T12:00:00.000Z');
+
+async function process(xml: string): Promise<ProcessModel> {
+  return (await parseBpmn(xml)).processes[0]!;
+}
+
+describe('throw events', () => {
+  it('a signal thrown inside the process wakes its own catchers', async () => {
+    const eng = new WorkflowEngine(await process(THROW_SIGNAL));
+    let snap = await eng.start();
+
+    // One branch waits for the signal; the other is about to throw it.
+    expect(snap.tokens.find((t) => t.nodeId === 'EsperarPagamento')?.waiting).toBe(true);
+
+    snap = await eng.completeTask(eng.tasks({ nodeId: 'Cobrar' })[0]!.tokenId);
+
+    // Nobody signalled from outside: the throw event did it.
+    expect(snap.completedNodes).toContain('EmitirNota');
+    expect(snap.status).toBe('completed');
+  });
+});
+
+describe('conditional boundary event', () => {
+  it('fires when the variables make its condition true', async () => {
+    const eng = new WorkflowEngine(await process(CONDITIONAL_BOUNDARY), {
+      variables: { urgente: false },
+    });
+    let snap = await eng.start();
+    expect(snap.completedNodes).not.toContain('Priorizar');
+
+    // The other branch marks the case as urgent.
+    snap = await eng.completeTask(eng.tasks({ nodeId: 'Sinalizar' })[0]!.tokenId, {
+      urgente: true,
+    });
+
+    expect(snap.completedNodes).toContain('Priorizar');
+    // Non-interrupting: the analysis is still open.
+    expect(eng.tasks({ nodeId: 'Analisar' })).toHaveLength(1);
+  });
+
+  it('does not fire twice for the same activity', async () => {
+    const eng = new WorkflowEngine(await process(CONDITIONAL_BOUNDARY), {
+      variables: { urgente: true },
+    });
+    const snap = await eng.start();
+    const priorizou = snap.history.filter((entry) => entry.nodeId === 'Priorizar');
+    expect(priorizou.filter((entry) => entry.event === 'enter')).toHaveLength(1);
+  });
+});
+
+describe('cyclic timer', () => {
+  it('reads the repetitions of a cycle', () => {
+    expect(parseTimerCycle('R3/PT10M')).toEqual({ repetitions: 3, interval: 'PT10M' });
+    expect(parseTimerCycle('R/PT1H')).toEqual({ repetitions: null, interval: 'PT1H' });
+    expect(parseTimerCycle('PT10M')).toBeUndefined();
+  });
+
+  it('fires a non-interrupting boundary once per repetition', async () => {
+    let now = T0;
+    let cobrancas = 0;
+    const eng = new WorkflowEngine(await process(TIMER_CYCLE), { now: () => now });
+    eng.registerHandler('Cobrar', () => {
+      cobrancas += 1;
+    });
+
+    await eng.start();
+    for (let hour = 1; hour <= 5; hour++) {
+      now = T0 + hour * 3_600_000;
+      await eng.tick();
+    }
+
+    // R3: three reminders, then it stops even though time keeps passing.
+    expect(cobrancas).toBe(3);
+    expect(eng.tasks({ nodeId: 'Aguardar' })).toHaveLength(1);
+  });
+});
+
+describe('ad-hoc subprocess', () => {
+  it('runs every activity, with no sequence flow between them', async () => {
+    const done: string[] = [];
+    const eng = new WorkflowEngine(await process(AD_HOC));
+    for (const id of ['Ligar', 'Enviar', 'Registrar']) {
+      eng.registerHandler(id, () => {
+        done.push(id);
+      });
+    }
+
+    const snap = await eng.start();
+
+    expect(done.sort()).toEqual(['Enviar', 'Ligar', 'Registrar']);
+    expect(snap.completedNodes).toContain('Fechar');
+    expect(snap.status).toBe('completed');
+  });
+
+  it('stops early when the completion condition holds', async () => {
+    const done: string[] = [];
+    const eng = new WorkflowEngine(await process(AD_HOC));
+    eng.registerHandler('Ligar', () => {
+      done.push('Ligar');
+      return { resolvido: true }; // resolved on the first call
+    });
+    for (const id of ['Enviar', 'Registrar']) {
+      eng.registerHandler(id, () => {
+        done.push(id);
+      });
+    }
+
+    const snap = await eng.start();
+
+    expect(done).toContain('Ligar');
+    expect(snap.completedNodes).toContain('Fechar');
+    expect(snap.status).toBe('completed');
+  });
+
+  it('sequential ordering runs one activity at a time', async () => {
+    const eng = new WorkflowEngine(await process(AD_HOC_SEQUENTIAL));
+    await eng.start();
+
+    expect(eng.tasks()).toHaveLength(1);
+    expect(eng.tasks()[0]?.nodeId).toBe('Item1');
+
+    await eng.completeTask(eng.tasks()[0]!.tokenId);
+    expect(eng.tasks()[0]?.nodeId).toBe('Item2');
+
+    const snap = await eng.completeTask(eng.tasks()[0]!.tokenId);
+    expect(snap.status).toBe('completed');
+  });
+});
+
+describe('data mapping', () => {
+  async function model(): Promise<BpmnModel> {
+    return parseBpmn(DATA_MAPPING);
+  }
+
+  it('maps values in and out of the called process', async () => {
+    const m = await model();
+    const caller = m.processes.find((p) => p.id === 'Pedido')!;
+    const eng = new WorkflowEngine(caller, {
+      processes: m.processes,
+      variables: { valorPedido: 250, segredoDoChamador: 'nao vaza' },
+    });
+
+    let vistoDentro: Record<string, unknown> = {};
+    eng.registerHandler('Cobrar', (ctx) => {
+      vistoDentro = { ...ctx.variables };
+      return { recibo: `NF-${String(ctx.get('valor'))}` };
+    });
+
+    const started = await eng.start();
+    expect(started.status).toBe('waiting'); // parado na confirmação, dentro do chamado
+    const snap = await eng.completeTask(eng.tasks({ nodeId: 'Confirmar' })[0]!.tokenId);
+
+    // Entrou mapeado...
+    expect(vistoDentro.valor).toBe(250);
+    // ...e o processo chamado não enxerga o resto do chamador.
+    expect(vistoDentro.segredoDoChamador).toBeUndefined();
+    // ...e só o que foi mapeado volta, com o nome do chamador.
+    expect(snap.variables.reciboDaCobranca).toBe('NF-250');
+    expect(snap.variables.recibo).toBeUndefined();
+    expect(snap.status).toBe('completed');
+  });
+});
+
+describe('the new constructs survive a restart', () => {
+  it('keeps an ad-hoc queue and finishes it in another engine', async () => {
+    const p = await process(AD_HOC_SEQUENTIAL);
+    const first = new WorkflowEngine(p);
+    await first.start();
+    await first.completeTask(first.tasks()[0]!.tokenId);
+
+    const second = WorkflowEngine.restore(p, JSON.parse(JSON.stringify(first.getState())));
+    expect(second.tasks()[0]?.nodeId).toBe('Item2');
+
+    const snap = await second.completeTask(second.tasks()[0]!.tokenId);
+    expect(snap.status).toBe('completed');
+  });
+
+  it('keeps the isolation of a data-mapped call activity', async () => {
+    const model = await parseBpmn(DATA_MAPPING);
+    const caller = model.processes.find((p) => p.id === 'Pedido')!;
+    const first = new WorkflowEngine(caller, {
+      processes: model.processes,
+      variables: { valorPedido: 99 },
+    });
+    // Para na tarefa de usuário do processo chamado.
+    first.registerHandler('Cobrar', () => undefined);
+    const started = await first.start();
+    expect(started.status).toBe('waiting');
+
+    const state = JSON.parse(JSON.stringify(first.getState()));
+    const second = WorkflowEngine.restore(caller, state, { processes: model.processes });
+    const pendente = second.tasks({ nodeId: 'Confirmar' })[0]!;
+    const vistoDentro = pendente.variables;
+
+    const snap = await second.completeTask(pendente.tokenId, { recibo: 'NF-99' });
+    expect(snap.status).toBe('completed');
+    expect(vistoDentro.valorPedido).toBeUndefined(); // segue isolado
+    expect(snap.variables.reciboDaCobranca).toBe('NF-99');
+  });
+
+  it('keeps the repetitions left on a cyclic timer', async () => {
+    let now = T0;
+    const p = await process(TIMER_CYCLE);
+    const first = new WorkflowEngine(p, { now: () => now });
+    let cobrancas = 0;
+    first.registerHandler('Cobrar', () => {
+      cobrancas += 1;
+    });
+    await first.start();
+    now = T0 + 3_600_000;
+    await first.tick();
+
+    const second = WorkflowEngine.restore(p, JSON.parse(JSON.stringify(first.getState())), {
+      now: () => now,
+    });
+    second.registerHandler('Cobrar', () => {
+      cobrancas += 1;
+    });
+    for (let hour = 2; hour <= 6; hour++) {
+      now = T0 + hour * 3_600_000;
+      await second.tick();
+    }
+
+    expect(cobrancas).toBe(3); // uma antes do restart, duas depois
+  });
+});

--- a/packages/core/test/fixtures.ts
+++ b/packages/core/test/fixtures.ts
@@ -741,3 +741,124 @@ export const RECEIVE_TASK = `<?xml version="1.0" encoding="UTF-8"?>
     <bpmn:sequenceFlow id="f2" sourceRef="Enviar" targetRef="End" />
   </bpmn:process>
 </bpmn:definitions>`;
+
+export const THROW_SIGNAL = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions ${NS} id="Defs">
+  <bpmn:signal id="Sig" name="PedidoPago" />
+  <bpmn:process id="P" isExecutable="true">
+    <bpmn:startEvent id="Start" />
+    <bpmn:parallelGateway id="Split" />
+    <bpmn:userTask id="Cobrar" />
+    <bpmn:intermediateThrowEvent id="Avisar">
+      <bpmn:signalEventDefinition signalRef="Sig" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="EndCobranca" />
+    <bpmn:intermediateCatchEvent id="EsperarPagamento">
+      <bpmn:signalEventDefinition signalRef="Sig" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:task id="EmitirNota" />
+    <bpmn:endEvent id="End" />
+    <bpmn:sequenceFlow id="f0" sourceRef="Start" targetRef="Split" />
+    <bpmn:sequenceFlow id="fa" sourceRef="Split" targetRef="Cobrar" />
+    <bpmn:sequenceFlow id="fb" sourceRef="Split" targetRef="EsperarPagamento" />
+    <bpmn:sequenceFlow id="fa2" sourceRef="Cobrar" targetRef="Avisar" />
+    <bpmn:sequenceFlow id="fa3" sourceRef="Avisar" targetRef="EndCobranca" />
+    <bpmn:sequenceFlow id="fb2" sourceRef="EsperarPagamento" targetRef="EmitirNota" />
+    <bpmn:sequenceFlow id="fb3" sourceRef="EmitirNota" targetRef="End" />
+  </bpmn:process>
+</bpmn:definitions>`;
+
+export const CONDITIONAL_BOUNDARY = wrap(`
+    <bpmn:startEvent id="Start" />
+    <bpmn:parallelGateway id="Split" />
+    <bpmn:userTask id="Analisar" />
+    <bpmn:boundaryEvent id="FicouUrgente" attachedToRef="Analisar" cancelActivity="false">
+      <bpmn:conditionalEventDefinition>
+        <bpmn:condition xsi:type="bpmn:tFormalExpression">urgente === true</bpmn:condition>
+      </bpmn:conditionalEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:userTask id="Sinalizar" />
+    <bpmn:task id="Priorizar" />
+    <bpmn:endEvent id="EndUrgente" />
+    <bpmn:endEvent id="EndSinal" />
+    <bpmn:endEvent id="End" />
+    <bpmn:sequenceFlow id="f0" sourceRef="Start" targetRef="Split" />
+    <bpmn:sequenceFlow id="fa" sourceRef="Split" targetRef="Analisar" />
+    <bpmn:sequenceFlow id="fb" sourceRef="Split" targetRef="Sinalizar" />
+    <bpmn:sequenceFlow id="fa2" sourceRef="Analisar" targetRef="End" />
+    <bpmn:sequenceFlow id="fb2" sourceRef="Sinalizar" targetRef="EndSinal" />
+    <bpmn:sequenceFlow id="fc" sourceRef="FicouUrgente" targetRef="Priorizar" />
+    <bpmn:sequenceFlow id="fc2" sourceRef="Priorizar" targetRef="EndUrgente" />`);
+
+export const TIMER_CYCLE = wrap(`
+    <bpmn:startEvent id="Start" />
+    <bpmn:userTask id="Aguardar" />
+    <bpmn:boundaryEvent id="Lembrete" attachedToRef="Aguardar" cancelActivity="false">
+      <bpmn:timerEventDefinition>
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R3/PT1H</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:serviceTask id="Cobrar" />
+    <bpmn:endEvent id="EndLembrete" />
+    <bpmn:endEvent id="End" />
+    <bpmn:sequenceFlow id="f0" sourceRef="Start" targetRef="Aguardar" />
+    <bpmn:sequenceFlow id="f1" sourceRef="Aguardar" targetRef="End" />
+    <bpmn:sequenceFlow id="fb" sourceRef="Lembrete" targetRef="Cobrar" />
+    <bpmn:sequenceFlow id="fb2" sourceRef="Cobrar" targetRef="EndLembrete" />`);
+
+export const AD_HOC = wrap(`
+    <bpmn:startEvent id="Start" />
+    <bpmn:adHocSubProcess id="Atendimento" ordering="Parallel">
+      <bpmn:serviceTask id="Ligar" />
+      <bpmn:serviceTask id="Enviar" />
+      <bpmn:serviceTask id="Registrar" />
+      <bpmn:completionCondition xsi:type="bpmn:tFormalExpression">resolvido === true</bpmn:completionCondition>
+    </bpmn:adHocSubProcess>
+    <bpmn:task id="Fechar" />
+    <bpmn:endEvent id="End" />
+    <bpmn:sequenceFlow id="f0" sourceRef="Start" targetRef="Atendimento" />
+    <bpmn:sequenceFlow id="f1" sourceRef="Atendimento" targetRef="Fechar" />
+    <bpmn:sequenceFlow id="f2" sourceRef="Fechar" targetRef="End" />`);
+
+export const AD_HOC_SEQUENTIAL = wrap(`
+    <bpmn:startEvent id="Start" />
+    <bpmn:adHocSubProcess id="Checklist" ordering="Sequential">
+      <bpmn:userTask id="Item1" />
+      <bpmn:userTask id="Item2" />
+    </bpmn:adHocSubProcess>
+    <bpmn:endEvent id="End" />
+    <bpmn:sequenceFlow id="f0" sourceRef="Start" targetRef="Checklist" />
+    <bpmn:sequenceFlow id="f1" sourceRef="Checklist" targetRef="End" />`);
+
+export const DATA_MAPPING = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions ${NS} id="Defs">
+  <bpmn:process id="Cobranca" isExecutable="true">
+    <bpmn:startEvent id="CStart" />
+    <bpmn:serviceTask id="Cobrar" />
+    <bpmn:userTask id="Confirmar" />
+    <bpmn:endEvent id="CEnd" />
+    <bpmn:sequenceFlow id="c1" sourceRef="CStart" targetRef="Cobrar" />
+    <bpmn:sequenceFlow id="c2" sourceRef="Cobrar" targetRef="Confirmar" />
+    <bpmn:sequenceFlow id="c3" sourceRef="Confirmar" targetRef="CEnd" />
+  </bpmn:process>
+  <bpmn:process id="Pedido" isExecutable="true">
+    <bpmn:startEvent id="Start" />
+    <bpmn:callActivity id="Chamar" calledElement="Cobranca">
+      <bpmn:dataInputAssociation id="in1">
+        <bpmn:assignment>
+          <bpmn:from>valorPedido</bpmn:from>
+          <bpmn:to>valor</bpmn:to>
+        </bpmn:assignment>
+      </bpmn:dataInputAssociation>
+      <bpmn:dataOutputAssociation id="out1">
+        <bpmn:assignment>
+          <bpmn:from>recibo</bpmn:from>
+          <bpmn:to>reciboDaCobranca</bpmn:to>
+        </bpmn:assignment>
+      </bpmn:dataOutputAssociation>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="End" />
+    <bpmn:sequenceFlow id="f0" sourceRef="Start" targetRef="Chamar" />
+    <bpmn:sequenceFlow id="f1" sourceRef="Chamar" targetRef="End" />
+  </bpmn:process>
+</bpmn:definitions>`;

--- a/packages/core/test/variables.test.ts
+++ b/packages/core/test/variables.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { parseBpmn, processVariables, suggestVariables, WorkflowEngine } from '../src/index.js';
+import type { ProcessModel } from '../src/index.js';
+import { COMPENSATION, COMPLEX_GATEWAY, MI_COLLECTION } from './fixtures.js';
+
+async function process(xml: string): Promise<ProcessModel> {
+  return (await parseBpmn(xml)).processes[0]!;
+}
+
+describe('processVariables', () => {
+  it('finds the variables the gateways read, and where', async () => {
+    const usages = processVariables(await process(COMPENSATION));
+    const pago = usages.find((usage) => usage.name === 'pago')!;
+
+    expect(pago).toMatchObject({ kind: 'condition', suggestion: true });
+    expect(pago.expressions).toEqual(['pago === true']);
+    expect(pago.usedBy.length).toBeGreaterThan(0);
+  });
+
+  it('reports a multi-instance collection as such', async () => {
+    const usages = processVariables(await process(MI_COLLECTION));
+    const itens = usages.find((usage) => usage.name === 'itens')!;
+
+    expect(itens.kind).toBe('collection');
+    expect(itens.suggestion).toEqual(['item-1', 'item-2']);
+  });
+
+  it('leaves out what the engine provides or the process writes', async () => {
+    const names = processVariables(await process(MI_COLLECTION)).map((usage) => usage.name);
+
+    expect(names).not.toContain('loopCounter'); // engine
+    expect(names).not.toContain('item'); // multi-instance item
+    expect(names).not.toContain('resultado'); // output element
+    expect(names).not.toContain('resultados'); // output collection
+  });
+
+  it('ignores the count the complex gateway exposes', async () => {
+    const names = processVariables(await process(COMPLEX_GATEWAY)).map((usage) => usage.name);
+    expect(names).not.toContain('arrived');
+  });
+});
+
+describe('suggestions', () => {
+  const cases: [string, unknown][] = [
+    ['pago === true', true],
+    ['aprovado !== true', false],
+    ['valor > 1000', 1001],
+    ['valor >= 1000', 1000],
+    ['idade < 18', 17],
+    ['status === "ok"', 'ok'],
+    ["tipo === 'premium'", 'premium'],
+    ['ativo', true],
+  ];
+
+  /** Conditions live inside XML, so the comparison operators need escaping. */
+  const escape = (expression: string): string =>
+    expression.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+  it.each(cases)('%s -> %j', async (expression, expected) => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" targetNamespace="t" id="D">
+  <bpmn:process id="P" isExecutable="true">
+    <bpmn:startEvent id="S" />
+    <bpmn:exclusiveGateway id="Gw" default="fB" />
+    <bpmn:endEvent id="A" />
+    <bpmn:endEvent id="B" />
+    <bpmn:sequenceFlow id="f0" sourceRef="S" targetRef="Gw" />
+    <bpmn:sequenceFlow id="fA" sourceRef="Gw" targetRef="A">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${escape(expression)}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="fB" sourceRef="Gw" targetRef="B" />
+  </bpmn:process>
+</bpmn:definitions>`;
+    const [usage] = processVariables(await process(xml));
+    expect(usage?.suggestion).toEqual(expected);
+  });
+
+  it('produces variables that actually take the conditional path', async () => {
+    const model = await process(COMPENSATION);
+    const engine = new WorkflowEngine(model, { variables: suggestVariables(model) });
+    const snapshot = await engine.start();
+
+    // "pago" suggested as true, so the happy path runs and nothing is undone.
+    expect(snapshot.completedNodes).toContain('ViagemOk');
+    expect(snapshot.completedNodes).not.toContain('CancelarVoo');
+  });
+});


### PR DESCRIPTION
## UI do playground

- **Painel retrátil**: botão na borda recolhe/expande a lateral, a escolha fica guardada entre sessões e o diagrama é reenquadrado depois da transição.
- **Sobreposição corrigida**: `.diagram` não recortava o SVG e o painel podia ser espremido por ele. Agora o painel tem `flex: 0 0` e fica acima; medido no navegador: borda direita do SVG = 1040px = borda esquerda do painel, sem invasão.
- **"Reprisar" virou "Run"**.

## O diagrama diz quais variáveis precisa

Um gateway com `pago === true` só abre com essa variável, e não havia como adivinhar. O core passa a ler as expressões do próprio diagrama:

```ts
processVariables(process);
// [{ name: 'pago', kind: 'condition', expressions: ['pago === true'],
//    usedBy: ['Pagamento aprovado?'], suggestion: true }]
suggestVariables(process); // { valor: 1001, aprovado: true }
```

A sugestão sai da forma da expressão (`valor > 1000` → 1001, `status === "ok"` → "ok", coleção de multi-instância → dois itens). O playground abre a caixa JSON já preenchida e lista cada variável ao lado da expressão que a consome.

## Itens do BPMN que faltavam

| Item | Antes | Agora |
| --- | --- | --- |
| **adHocSubProcess** | escopo vazio, concluía na hora | roda as atividades sem fluxo de entrada, em paralelo ou uma a uma (`ordering`), com `completionCondition` encerrando cedo |
| **Mapeamento de dados** | ignorado | `dataInputAssociation`/`dataOutputAssociation` (`assignment/from/to`) copiam para dentro e para fora, **isolando** o processo chamado |
| **Evento de lançamento** | pass-through | sinal e mensagem são entregues aos assinantes do próprio processo |
| **Boundary condicional** | só por `signal()` | reavaliado a cada quiescência, uma vez por ativação |
| **Timer cíclico** | disparava uma vez | `R3/PT1H` repete em boundary não interrompente, com as repetições no estado serializado |

O mapeamento de dados revelou um bug real: uma variável nova criada dentro de um escopo isolado ia parar no escopo do **chamador**. A escrita agora para na fronteira do escopo mais externo visível.

## Verificação

`npm run verify` do zero: exit 0, **173 testes em 24 arquivos** (eram 148). Cobertos: ad-hoc paralelo/sequencial/condição, mapeamento com isolamento (inclusive sobrevivendo a restart), throw de sinal, boundary condicional (dispara uma vez), ciclo R3 (três disparos e para), e as 13 asserções de descoberta de variáveis.

No navegador, medido por CDP: painel recolhe para 0px e volta, JSON pré-preenchido em `processo-compras` (`{valor: 1001, aprovado: true}`) e em `processo-aprovacao-coletiva` (coleção com 2 itens → 2 tarefas).