### PR TITLE
fix(playground): fazer o botão Run funcionar

### DIFF
--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -42,8 +42,10 @@ Há dois modos, alternados pelos botões "Executar" e "Editar".
 - O painel mostra status, variáveis e o histórico da execução; o diagrama
   destaca nós concluídos, tokens ativos, atividades em espera e fluxos
   percorridos.
-- "Run" refaz a execução passo a passo a partir do histórico; "Métricas" liga
-  etiquetas de tempo médio em cada atividade.
+- "Run" executa o processo e mostra o caminho passo a passo no diagrama. Se já
+  houver uma execução em andamento, reprisa o que aconteceu até ali; durante a
+  animação o botão vira "Parar". "Métricas" liga etiquetas de tempo médio em
+  cada atividade.
 - O painel **Variáveis do processo** lista o que o diagrama lê, com a expressão
   que consome cada variável, e a caixa JSON já vem preenchida com valores que
   fazem o processo andar.

--- a/apps/playground/src/main.ts
+++ b/apps/playground/src/main.ts
@@ -7,6 +7,7 @@ import {
   type EngineMode,
   type ExecutionSnapshot,
   type FlowNode,
+  type HistoryEntry,
   type PendingTask,
   type TokenSnapshot,
   type VariableUsage,
@@ -138,10 +139,7 @@ async function loadDiagram(xml: string): Promise<void> {
   renderVariableHints();
   await viewer.load(xml);
   teardownEngine();
-  if (replayTimer !== undefined) {
-    window.clearInterval(replayTimer);
-    replayTimer = undefined;
-  }
+  stopAnimation();
   metricsShown = false;
   els.log.replaceChildren();
   els.actions.replaceChildren();
@@ -336,25 +334,55 @@ function renderTimers(): void {
   els.timers.append(button);
 }
 
-/** Reprisa a execução passo a passo a partir do histórico. */
-function replayRun(): void {
-  if (!engine || replayTimer !== undefined) return;
-  const replay = new ExecutionReplay(engine.snapshot().history);
-  if (replay.length === 0) return;
+/**
+ * Executa o processo e mostra o caminho passo a passo no diagrama. Se já houver
+ * uma execução em andamento, reprisa o que aconteceu até aqui; clicar de novo
+ * durante a animação interrompe.
+ */
+async function runAndAnimate(): Promise<void> {
+  if (replayTimer !== undefined) {
+    stopAnimation();
+    return;
+  }
+  try {
+    if (!engine) {
+      engine = newEngine('auto', readVariables());
+      render(await engine.start());
+    }
+    animate(engine.snapshot().history);
+  } catch (error) {
+    fail(error);
+  }
+}
+
+/** Percorre o histórico quadro a quadro sobre o diagrama. */
+function animate(history: HistoryEntry[]): void {
+  const replay = new ExecutionReplay(history);
+  if (replay.length === 0) {
+    els.status.textContent = 'Nada para mostrar: o processo não executou nenhum passo.';
+    return;
+  }
+  els.replay.textContent = 'Parar';
   viewer.clear();
   replayTimer = window.setInterval(() => {
     const frame = replay.next();
     if (!frame) {
-      window.clearInterval(replayTimer);
-      replayTimer = undefined;
-      if (engine) render(engine.snapshot());
+      stopAnimation();
       return;
     }
     viewer.applyReplayFrame(frame);
-    els.status.textContent = `Replay ${frame.index + 1}/${replay.length}: ${label(
+    els.status.textContent = `Passo ${frame.index + 1}/${replay.length}: ${label(
       frame.entry.nodeId,
     )} (${frame.entry.event})`;
   }, 400);
+}
+
+/** Encerra a animação e devolve o diagrama ao estado real da execução. */
+function stopAnimation(): void {
+  if (replayTimer !== undefined) window.clearInterval(replayTimer);
+  replayTimer = undefined;
+  els.replay.textContent = 'Run';
+  if (engine) render(engine.snapshot());
 }
 
 /** Liga/desliga as etiquetas de tempo médio por atividade. */
@@ -525,7 +553,7 @@ els.reset.addEventListener('click', () => {
   if (currentXml) void loadDiagram(currentXml);
 });
 els.fit.addEventListener('click', () => viewer.fit());
-els.replay.addEventListener('click', () => replayRun());
+els.replay.addEventListener('click', () => void runAndAnimate());
 els.panelToggle.addEventListener('click', () => togglePanel());
 els.metrics.addEventListener('click', () => toggleMetrics());
 


### PR DESCRIPTION
## O que estava acontecendo

O botão só reprisava um histórico **já existente**. Num diagrama recém-carregado não havia histórico, então ele retornava na primeira linha e não acontecia nada: sem animação, sem mensagem, sem erro no console.

Reproduzido no navegador antes de mexer:

```
1) Run sem executar antes  -> status antes: 'Diagrama carregado: Processo de Compras.'
                              status depois: 'Diagrama carregado: Processo de Compras.'   (nada mudou)
2) Run depois de executar  -> 'Replay 3/16: Preencher Formulário (enter)'                 (funcionava)
```

## Correção

O botão passa a fazer o que o nome diz:

- **Sem execução**: executa o processo com as variáveis da caixa e anima o caminho passo a passo.
- **Com execução em andamento**: reprisa o que já aconteceu, sem recomeçar.
- **Durante a animação**: o rótulo vira "Parar" e clicar interrompe, devolvendo o estado real da execução.
- **Execução sem passos**: diz isso na barra de estado, em vez de falhar em silêncio.

## Verificação no navegador

```
1) Run direto            -> 'Passo 2/16: Solicitação de Compra (complete)' | botão 'Parar'
                            ao terminar: 'completed - 0 token(s) ativos, 8 nó(s)' | botão 'Run'
2) Run -> Parar          -> durante: 'Parar' | depois: 'Run' | estado real restaurado
3) Run após execução     -> 'Passo 2/4: Proposta Recebida (complete)' (reprisa, não re-executa)
```

Sem erros de console nos três cenários. `npm run verify` do zero: exit 0, 173 testes em 24 arquivos.