### PR TITLE
feat: perguntar no gateway quando o processo não tem onde parar

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,21 @@ aplicar `assignments` abre exatamente aquele caminho. No playground, o botão
 depende de uma pessoa — concluir a atividade, informar um valor, escolher o
 caminho — em vez de decidir sozinho e mostrar só o resultado.
 
+Um processo sem nenhuma tarefa não tem onde parar, e mesmo assim decide: para
+esses, o motor aceita um `decide` e pergunta no próprio gateway.
+
+```ts
+new WorkflowEngine(process, {
+  decide: async ({ name, options, suggested }) => {
+    // options traz cada ramo com sua condição; suggested, o que os dados diriam
+    return await perguntarAoOperador(name, options, suggested);
+  },
+});
+```
+
+Sem essa opção nada muda: o gateway decide pelos dados, como manda a
+especificação.
+
 ![Diálogo do passo a passo perguntando o valor e o caminho a seguir](docs/media/passo-a-passo-decisao.png)
 
 ## Timers

--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -46,7 +46,9 @@ Há dois modos, alternados pelos botões "Executar" e "Editar".
   parada, abre um diálogo com o que depende de uma pessoa — concluir a
   atividade, informar um valor, escolher o caminho do gateway seguinte (as
   opções vêm das condições do próprio diagrama, e marcar uma preenche os valores
-  que levam até ela). "Seguir sem perguntar" responde o resto sozinho e "Parar"
+  que levam até ela). Num processo sem tarefa nenhuma — o
+  `processo-viagem-compensacao`, por exemplo — a pergunta acontece no próprio
+  gateway, quando o token chega nele: a escolha vale mais que a condição. "Seguir sem perguntar" responde o resto sozinho e "Parar"
   interrompe, devolvendo o diagrama ao estado real. Durante a condução o botão
   vira "Parar". "Métricas" liga etiquetas de tempo médio em cada atividade.
 - O painel **Variáveis do processo** lista o que o diagrama lê, com a expressão

--- a/apps/playground/src/main.ts
+++ b/apps/playground/src/main.ts
@@ -11,6 +11,7 @@ import {
   type EngineMode,
   type ExecutionSnapshot,
   type FlowNode,
+  type GatewayDecision,
   type HistoryEntry,
   type PendingTask,
   type TokenSnapshot,
@@ -98,6 +99,13 @@ let guiding = false;
 let stopRequested = false;
 /** O operador pediu para seguir até o fim sem mais perguntas. */
 let autoAnswer = false;
+/** Passos do histórico já animados na condução atual. */
+let shownSteps = 0;
+/**
+ * Gateways cuja escolha já foi respondida no diálogo da atividade anterior —
+ * quando o token chegar neles, decidem pelos dados sem perguntar de novo.
+ */
+const answeredGateways = new Set<string>();
 
 /** Intervalo entre dois passos da animação, em milissegundos. */
 const STEP_MS = 500;
@@ -186,7 +194,7 @@ function readVariables(): Record<string, unknown> {
 function newEngine(mode: EngineMode, variables: Record<string, unknown>): WorkflowEngine {
   const process = currentModel?.processes[0];
   if (!process) throw new Error('Nenhum processo executável.');
-  const created = new WorkflowEngine(process, { mode, variables });
+  const created = new WorkflowEngine(process, { mode, variables, decide: onGatewayDecision });
   unbindViewer = viewer.bindEngine(created);
   created.on('node.enter', (e) => log(`Entrou: ${label(e.nodeId)}`));
   created.on('wait', (e) => log(`Aguardando: ${label(e.nodeId)} (${e.reason})`));
@@ -379,11 +387,12 @@ async function guidedRun(): Promise<void> {
     unbindViewer = undefined;
     viewer.clear();
 
+    shownSteps = 0;
+    answeredGateways.clear();
     let snapshot = engine.snapshot();
     if (snapshot.status === 'idle') snapshot = await engine.start();
-    let shown = 0;
     for (let step = 0; step < MAX_STEPS && !stopRequested; step++) {
-      shown = await animateFrom(snapshot.history, shown);
+      shownSteps = await animateFrom(snapshot.history, shownSteps);
       if (stopRequested || snapshot.status !== 'waiting') break;
       // O painel acompanha a parada, para o diálogo e a lateral contarem a
       // mesma história.
@@ -448,6 +457,8 @@ interface Step {
   request: StepRequest;
   /** Resposta usada quando o operador pediu para seguir sem perguntar. */
   defaults: Record<string, unknown>;
+  /** Gateways adiante cuja escolha este diálogo já cobre. */
+  decided: string[];
   apply: (answer: StepAnswer) => Promise<ExecutionSnapshot>;
 }
 
@@ -460,6 +471,9 @@ async function answerStep(snapshot: ExecutionSnapshot): Promise<ExecutionSnapsho
     : await prompt.ask(step.request);
   if (answer.action === 'stop') return undefined;
   if (answer.action === 'auto') autoAnswer = true;
+  // O gateway logo à frente não precisa perguntar de novo: acabou de ser
+  // respondido aqui, e os valores informados é que vão decidir.
+  for (const nodeId of step.decided) answeredGateways.add(nodeId);
   return step.apply(answer);
 }
 
@@ -480,6 +494,7 @@ function nextStep(snapshot: ExecutionSnapshot): Step | undefined {
         confirmLabel: 'Tentar de novo',
       },
       defaults: {},
+      decided: [],
       apply: () => active.retryTask(incident.tokenId),
     };
   }
@@ -504,6 +519,7 @@ function nextStep(snapshot: ExecutionSnapshot): Step | undefined {
       confirmLabel: 'Adiantar relógio',
     },
     defaults: {},
+    decided: [],
     apply: () => active.tick(timer),
   };
 }
@@ -528,6 +544,7 @@ function taskStep(active: WorkflowEngine, task: PendingTask): Step {
       confirmLabel: timer ? 'Disparar agora' : trigger ? 'Sinalizar' : 'Concluir',
     },
     defaults: ahead.defaults,
+    decided: ahead.decided,
     apply: (answer) =>
       trigger
         ? active.signal(task.nodeId, answer.values)
@@ -563,7 +580,52 @@ function gatewayStep(active: WorkflowEngine, token: TokenSnapshot): Step {
       confirmLabel: 'Sinalizar',
     },
     defaults: {},
+    decided: [],
     apply: (answer) => active.signal(answer.choiceId ?? first ?? token.nodeId),
+  };
+}
+
+/**
+ * O gateway pergunta antes de rotear o token. Só durante a condução, e só
+ * quando a escolha não foi respondida no diálogo da atividade anterior — fora
+ * disso o processo decide pelos dados, como manda a especificação.
+ */
+async function onGatewayDecision(decision: GatewayDecision): Promise<string | undefined> {
+  if (!guiding || stopRequested || !engine) return undefined;
+  if (answeredGateways.delete(decision.nodeId)) return undefined;
+  // Alcança o gateway no diagrama antes de perguntar sobre ele.
+  shownSteps = await animateFrom(engine.snapshot().history, shownSteps);
+  if (stopRequested || autoAnswer) return undefined;
+
+  renderTimers();
+  const answer = await prompt.ask(gatewayRequest(decision));
+  if (answer.action === 'stop') {
+    stopRequested = true;
+    return undefined;
+  }
+  if (answer.action === 'auto') autoAnswer = true;
+  return answer.choiceId;
+}
+
+/** O diálogo de um gateway: os caminhos, e o que os dados escolheriam. */
+function gatewayRequest(decision: GatewayDecision): StepRequest {
+  const byData = decision.options.find((option) => option.flowId === decision.suggested[0]);
+  const name = (option: (typeof decision.options)[number]): string =>
+    option.name ?? label(option.targetId);
+  return {
+    title: decision.name ?? decision.nodeId,
+    reason: byData
+      ? `Pelas condições o processo iria para "${name(byData)}"; a escolha aqui vale mais.`
+      : 'Nenhuma condição fecha: escolha por onde seguir.',
+    badges: [],
+    choices: decision.options.map((option) => ({
+      id: option.flowId,
+      label: name(option),
+      hint: option.condition ?? (option.isDefault ? 'caminho padrão' : undefined),
+    })),
+    selected: decision.suggested[0],
+    fields: [],
+    confirmLabel: 'Seguir',
   };
 }
 
@@ -579,6 +641,7 @@ function decisionPrompt(
   choices: PromptChoice[];
   fields: PromptField[];
   defaults: Record<string, unknown>;
+  decided: string[];
   selected?: string;
 } {
   const process = currentModel?.processes[0];
@@ -612,7 +675,13 @@ function decisionPrompt(
       });
     }
   });
-  return { choices, fields, defaults, selected };
+  return {
+    choices,
+    fields,
+    defaults,
+    decided: decisions.map((decision) => decision.nodeId),
+    selected,
+  };
 }
 
 /** O caminho que as variáveis de agora já escolheriam. */

--- a/docs/BPMN-STANDARD.md
+++ b/docs/BPMN-STANDARD.md
@@ -257,6 +257,10 @@ expressão que ainda assim lança, ou que não retorna `true`, é tratada como f
    mensagem/sinal ou pelo id do elemento.
 6. **DMN está fora de escopo.** `businessRuleTask` executa o handler que você
    registrar, e é por ali que um motor de decisão entra.
+7. **`options.decide`.** Extensão opcional: quando registrada, o gateway
+   exclusivo/inclusivo pergunta ao host antes de rotear, e a resposta se sobrepõe
+   às condições. Serve a simulação e a decisão humana; sem ela nada muda, o
+   gateway decide pelos dados como manda a especificação.
 
 ## Medição
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -78,6 +78,11 @@ Opções:
 
 - `mode`: `"automation"` (padrão) pausa em tarefas de usuário/captura;
   `"auto"` resolve todas as esperas para simular uma execução completa.
+- `decide`: chamado antes de um gateway exclusivo/inclusivo rotear o token, para
+  uma pessoa (ou outro sistema) escolher o ramo. Recebe as alternativas com suas
+  condições e o que os dados escolheriam; devolver `undefined` mantém a decisão
+  do motor. Sem essa opção, o gateway decide pelos dados, como manda a
+  especificação.
 - `processes`: demais processos do arquivo, para `callActivity` executar o
   processo referenciado (normalmente `model.processes`).
 - `onHandlerError`: `"fail"` (padrão) derruba a execução; `"incident"` segura o

--- a/packages/core/src/engine/engine.ts
+++ b/packages/core/src/engine/engine.ts
@@ -951,7 +951,7 @@ export class WorkflowEngine {
         continue;
       }
       // No ready tokens: check inclusive joins that can now fire.
-      if (this.fireReadyInclusiveJoins()) continue;
+      if (await this.fireReadyInclusiveJoins()) continue;
       // A conditional event fires as soon as its condition holds.
       if (this.fireReadyConditionalEvents()) continue;
       // An ad-hoc subprocess may declare itself done before running everything.
@@ -1003,19 +1003,19 @@ export class WorkflowEngine {
         this.park(token, 'catchEvent');
         return;
       case node.kind === 'exclusiveGateway':
-        this.handleExclusive(token, node);
+        await this.handleExclusive(token, node);
         return;
       case node.kind === 'parallelGateway':
         this.handleParallel(token, node);
         return;
       case node.kind === 'inclusiveGateway':
-        this.handleInclusive(token, node);
+        await this.handleInclusive(token, node);
         return;
       case node.kind === 'eventBasedGateway':
         this.handleEventBased(token, node);
         return;
       case node.kind === 'complexGateway':
-        this.handleComplex(token, node);
+        await this.handleComplex(token, node);
         return;
       case node.kind === 'subProcess' ||
         node.kind === 'transaction' ||
@@ -1521,10 +1521,12 @@ export class WorkflowEngine {
 
   // --- Gateways ----------------------------------------------------------
 
-  private handleExclusive(token: RuntimeToken, node: FlowNode): void {
+  private async handleExclusive(token: RuntimeToken, node: FlowNode): Promise<void> {
     this.completeNode(token);
     const flows = token.scope.graph.outgoing(node);
-    const chosen = this.firstMatching(flows, node, token.scope) ?? this.defaultFlow(flows, node);
+    const byData = this.firstMatching(flows, node, token.scope) ?? this.defaultFlow(flows, node);
+    // Exclusive means one: whatever the hook answers, only the first is taken.
+    const chosen = (await this.chooseFlows(token, node, flows, byData ? [byData] : []))[0];
     if (!chosen) {
       this.fail(new BpmnExecutionError(`Exclusive gateway ${node.id} has no valid outgoing flow.`));
       return;
@@ -1553,7 +1555,7 @@ export class WorkflowEngine {
     this.discard(token);
   }
 
-  private handleInclusive(token: RuntimeToken, node: FlowNode): void {
+  private async handleInclusive(token: RuntimeToken, node: FlowNode): Promise<void> {
     if (node.incoming.length > 1) {
       const key = `${token.scope.id}:${node.id}`;
       const buffer = this.inclusiveBuffers.get(key) ?? [];
@@ -1564,7 +1566,7 @@ export class WorkflowEngine {
       return;
     }
     this.completeNode(token);
-    this.inclusiveSplit(token, node);
+    await this.inclusiveSplit(token, node);
     this.discard(token);
   }
 
@@ -1573,8 +1575,8 @@ export class WorkflowEngine {
    * expression turns true (the number of tokens that arrived is exposed as
    * `arrived`); without one it behaves like an inclusive gateway.
    */
-  private handleComplex(token: RuntimeToken, node: FlowNode): void {
-    this.handleInclusive(token, node);
+  private async handleComplex(token: RuntimeToken, node: FlowNode): Promise<void> {
+    await this.handleInclusive(token, node);
   }
 
   private handleEventBased(token: RuntimeToken, node: FlowNode): void {
@@ -1589,6 +1591,40 @@ export class WorkflowEngine {
   }
 
   // --- Flow selection ----------------------------------------------------
+
+  /**
+   * Lets `options.decide` route the token instead of the conditions. Without a
+   * hook — or when it answers nothing the gateway recognizes — the data-driven
+   * choice stands.
+   */
+  private async chooseFlows(
+    token: RuntimeToken,
+    node: FlowNode,
+    flows: SequenceFlow[],
+    byData: SequenceFlow[],
+  ): Promise<SequenceFlow[]> {
+    if (!this.options.decide) return byData;
+    const answer = await this.options.decide({
+      nodeId: node.id,
+      nodeKind: node.kind,
+      options: flows.map((flow) => ({
+        flowId: flow.id,
+        targetId: flow.targetRef,
+        isDefault: flow.isDefault === true || flow.id === node.default,
+        ...(flow.name ? { name: flow.name } : {}),
+        ...(flow.conditionExpression ? { condition: flow.conditionExpression } : {}),
+      })),
+      suggested: byData.map((flow) => flow.id),
+      variables: this.mergedVariables(token.scope),
+      ...(node.name ? { name: node.name } : {}),
+    });
+    if (answer === undefined) return byData;
+    const ids = typeof answer === 'string' ? [answer] : answer;
+    const picked = ids
+      .map((id) => flows.find((flow) => flow.id === id))
+      .filter((flow): flow is SequenceFlow => flow !== undefined);
+    return picked.length > 0 ? picked : byData;
+  }
 
   private firstMatching(
     flows: SequenceFlow[],
@@ -1610,7 +1646,7 @@ export class WorkflowEngine {
     return undefined;
   }
 
-  private inclusiveSplit(token: RuntimeToken, node: FlowNode): void {
+  private async inclusiveSplit(token: RuntimeToken, node: FlowNode): Promise<void> {
     const flows = token.scope.graph.outgoing(node);
     const variables = this.mergedVariables(token.scope);
     const taken = flows.filter(
@@ -1618,12 +1654,13 @@ export class WorkflowEngine {
         f.id !== node.default &&
         (!f.conditionExpression || evaluateCondition(f.conditionExpression, variables)),
     );
-    const chosen =
+    const byData =
       taken.length > 0
         ? taken
         : this.defaultFlow(flows, node)
           ? [this.defaultFlow(flows, node)!]
           : [];
+    const chosen = await this.chooseFlows(token, node, flows, byData);
     if (chosen.length === 0) {
       this.fail(new BpmnExecutionError(`Inclusive gateway ${node.id} has no valid outgoing flow.`));
       return;
@@ -1935,7 +1972,7 @@ export class WorkflowEngine {
 
   // --- Inclusive join firing --------------------------------------------
 
-  private fireReadyInclusiveJoins(): boolean {
+  private async fireReadyInclusiveJoins(): Promise<boolean> {
     for (const [key, buffer] of this.inclusiveBuffers) {
       if (buffer.length === 0) continue;
       const first = buffer[0]!;
@@ -1951,7 +1988,7 @@ export class WorkflowEngine {
       this.inclusiveBuffers.delete(key);
       this.completeNode(first);
       // Merge all buffered tokens into a single continuation.
-      this.inclusiveSplit(first, node);
+      await this.inclusiveSplit(first, node);
       return true;
     }
     return false;

--- a/packages/core/src/engine/types.ts
+++ b/packages/core/src/engine/types.ts
@@ -94,8 +94,48 @@ export interface ExecutionSnapshot {
  */
 export type EngineMode = 'automation' | 'auto';
 
+/** One outgoing flow offered to a {@link DecisionHandler}. */
+export interface GatewayOption {
+  flowId: string;
+  targetId: string;
+  name?: string;
+  condition?: string;
+  isDefault: boolean;
+}
+
+/** A branching gateway, handed to the caller so a person can decide instead. */
+export interface GatewayDecision {
+  nodeId: string;
+  nodeKind: ElementKind;
+  name?: string;
+  /** Outgoing flows, in document order. */
+  options: GatewayOption[];
+  /** Flow ids the conditions would take on their own. */
+  suggested: string[];
+  /** Variables visible at the gateway. */
+  variables: Record<string, unknown>;
+}
+
+/**
+ * Decides which flow(s) leave a gateway, overriding the conditions.
+ *
+ * Returning `undefined` (or an id the gateway does not have) keeps the
+ * engine's own decision, so the hook can answer some gateways and let the data
+ * answer the rest. An exclusive gateway takes the first id returned; an
+ * inclusive one takes all of them.
+ */
+export type DecisionHandler = (
+  decision: GatewayDecision,
+) => string | string[] | undefined | Promise<string | string[] | undefined>;
+
 export interface EngineOptions {
   mode?: EngineMode;
+  /**
+   * Asked before an exclusive/inclusive gateway routes a token, so a person (or
+   * another system) can choose the branch. Absent by default: gateways decide
+   * from the data, as the specification says.
+   */
+  decide?: DecisionHandler;
   /**
    * Clock used to schedule timer events. Defaults to `Date.now`; inject a fake
    * one to test timers without waiting.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,9 +32,12 @@ export { evaluateCondition, evaluateExpression } from './engine/expression.js';
 export { Emitter } from './engine/emitter.js';
 export type {
   ActivityMetrics,
+  DecisionHandler,
   EngineEvents,
   EngineMode,
   EngineOptions,
+  GatewayDecision,
+  GatewayOption,
   ExecutionSnapshot,
   ExecutionStatus,
   HistoryEntry,

--- a/packages/core/test/decide.test.ts
+++ b/packages/core/test/decide.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import { parseBpmn, WorkflowEngine } from '../src/index.js';
+import type { GatewayDecision, ProcessModel } from '../src/index.js';
+import { EXCLUSIVE, INCLUSIVE, PARALLEL } from './fixtures.js';
+
+async function process(xml: string): Promise<ProcessModel> {
+  return (await parseBpmn(xml)).processes[0]!;
+}
+
+describe('options.decide', () => {
+  it('routes an exclusive gateway against what the data says', async () => {
+    const model = await process(EXCLUSIVE);
+    const engine = new WorkflowEngine(model, {
+      // amount is unset, so the conditions would take the default branch.
+      decide: () => 'fHigh',
+    });
+    const snapshot = await engine.start();
+
+    expect(snapshot.completedNodes).toContain('High');
+    expect(snapshot.completedNodes).not.toContain('Low');
+  });
+
+  it('describes the gateway it is asking about', async () => {
+    const decide = vi.fn<(decision: GatewayDecision) => undefined>(() => undefined);
+    // amount is 50, under the `amount > 100` of the conditional branch.
+    await new WorkflowEngine(await process(EXCLUSIVE), {
+      variables: { amount: 50 },
+      decide,
+    }).start();
+
+    expect(decide).toHaveBeenCalledTimes(1);
+    expect(decide.mock.calls[0]![0]).toMatchObject({
+      nodeId: 'Gw',
+      nodeKind: 'exclusiveGateway',
+      suggested: ['fLow'], // under the threshold, so the default branch
+      variables: { amount: 50 },
+    });
+    expect(decide.mock.calls[0]![0].options).toEqual([
+      { flowId: 'fHigh', targetId: 'High', condition: 'amount > 100', isDefault: false },
+      { flowId: 'fLow', targetId: 'Low', isDefault: true },
+    ]);
+  });
+
+  it('keeps the engine decision when the hook answers nothing it knows', async () => {
+    const model = await process(EXCLUSIVE);
+    const engine = new WorkflowEngine(model, {
+      variables: { amount: 50 },
+      decide: () => 'flow-que-nao-existe',
+    });
+    const snapshot = await engine.start();
+
+    expect(snapshot.completedNodes).toContain('Low');
+  });
+
+  it('opens several branches of an inclusive gateway', async () => {
+    const model = await process(INCLUSIVE);
+    const engine = new WorkflowEngine(model, { decide: () => ['fx', 'fy'] });
+    const snapshot = await engine.start();
+
+    expect(snapshot.completedNodes).toEqual(expect.arrayContaining(['X', 'Y']));
+    expect(snapshot.completedNodes).not.toContain('Z');
+    expect(snapshot.status).toBe('completed');
+  });
+
+  it('is not asked about a parallel gateway: there is nothing to choose', async () => {
+    const decide = vi.fn(() => undefined);
+    await new WorkflowEngine(await process(PARALLEL), { decide }).start();
+
+    expect(decide).not.toHaveBeenCalled();
+  });
+
+  it('may answer asynchronously, like a person would', async () => {
+    const model = await process(EXCLUSIVE);
+    const engine = new WorkflowEngine(model, {
+      decide: async (decision) => {
+        await Promise.resolve();
+        return decision.options.find((option) => !option.isDefault)?.flowId;
+      },
+    });
+    const snapshot = await engine.start();
+
+    expect(snapshot.completedNodes).toContain('High');
+  });
+});


### PR DESCRIPTION
## O problema

No `processo-viagem-compensacao` o pop-up não aparecia. O diagrama é só service
task: nada para, e a única escolha — "Pagamento aprovado?" — acontece dentro do
`drain()`, decidida pelos dados. O passo a passo, que só perguntava em estados
de espera, não tinha onde interromper.

## No core: `options.decide`

O motor passa a chamar um hook antes de um gateway exclusivo/inclusivo rotear o
token:

```ts
new WorkflowEngine(process, {
  decide: async ({ name, options, suggested, variables }) => flowId,
});
```

- `options`: cada ramo com nome, alvo, condição e se é o padrão
- `suggested`: o que as condições escolheriam sozinhas
- devolver `undefined` (ou um id que o gateway não tem) mantém a decisão do
  motor, então dá para responder uns gateways e deixar os outros com os dados
- exclusivo toma o primeiro id devolvido; inclusivo toma todos
- gateway paralelo não é consultado: não há o que escolher

Sem a opção nada muda — está registrado como extensão em `docs/BPMN-STANDARD.md`.

## No playground

A animação alcança o gateway, o diálogo abre nele e a escolha vale mais que a
condição ("Pelas condições o processo iria para *Sim*; a escolha aqui vale
mais"). O gateway logo depois de uma atividade **não** pergunta duas vezes: quem
respondeu no diálogo da atividade já informou os valores que decidem.

## Verificação

`npm run verify` do zero: exit 0, **186 testes em 26 arquivos** (6 novos em
`packages/core/test/decide.test.ts`: sobrepor a condição, descrever o gateway,
ignorar resposta desconhecida, abrir vários ramos do inclusivo, não ser chamado
no paralelo, responder de forma assíncrona).

No navegador (CDP), sem nenhum erro de console:

```
viagem-compensacao -> diálogo 'Pagamento aprovado?' com '* Sim [pago === true]' e 'Não [caminho padrão]'
  escolher "Não"   -> Desfazer Reservas -> Cancelar Hotel -> Cancelar Voo -> Viagem Cancelada
  escolher "Sim"   -> Viagem Confirmada, sem compensar nada
compras            -> 'Preencher Formulário' -> 'Aprovação Gerencial' -> fim (o gateway não repergunta)
Iniciar / Executar tudo -> nenhum diálogo
```